### PR TITLE
Push main branch with release version

### DIFF
--- a/R/auto.R
+++ b/R/auto.R
@@ -55,6 +55,7 @@ pre_release_impl <- function(which, force) {
 
   # bump version on main branch to version set by user
   bump_version(which)
+  push_to_new(remote_name, force)
 
   # switch to release branch and update cran-comments
   release_branch <- create_release_branch(force)


### PR DESCRIPTION
This is a really important step which is currently missing for my workflow: pushing the main branch with the release version before bumping to devel again.

We are following a dev/release pkgdown versioning in mlr-org and without this step, the pkgdown site for the release version is never built when using `fledge::pre_release()`.

Currently there is one push which contains two commits

- the one containing the version bump to the release version (e.g. 0.4.0)
- the one containing the version bump to the next devel version (e.g. 0.4.0.9000)

In this scenario, the CI run on the package source with the version  0.4.0.9000 and hence does not/never build the release page.

I am aware that this might be an opinionated workflow adjustment but I hope that adding an additional `git push` might not hurt that much. Otherwise I need to do complex git resets into history and trigger a CI build manually.