### PR TITLE
add installation instructions from R-universe

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,13 @@ Click on the image to show in a separate tab.
 
 ## Installation
 
-Install from GitHub using
+Install from Cynkra R-universe using:
+
+```r
+install.packages('fledge', repo = 'https://cynkra.r-universe.dev')
+```
+
+Or install from GitHub using:
 
 ```r
 devtools::install_github("cynkra/fledge")


### PR DESCRIPTION
Fix #119

@krlmlr where does `downlit::readme_document` live? I wasn't able to knit the README (by the way what a pity that there's no knit readme PR command :grin: ).