### PR TITLE
fail earlier when force=FALSE?

### DIFF
--- a/R/tag-version.R
+++ b/R/tag-version.R
@@ -8,19 +8,20 @@ tag_version_impl <- function(force) {
   if (fledge_chatty()) cli_h2("Tagging Version")
 
   tag <- paste0("v", version)
-  if (tag %in% gert::git_tag_list()$name) {
+
+  if (tag_already_exist(tag)) {
     if (!force) {
       if (gert::git_commit_info(tag)$id == gert::git_log(max = 1)$commit) {
         if (fledge_chatty()) {
           cli_alert_info("Tag {.field {tag}} exists and points to the current commit.")
         }
-      } else {
-        abort(paste0("Tag ", tag, " exists, use `force = TRUE` to overwrite."))
       }
-    } else {
-      if (fledge_chatty()) cli_alert("Deleting tag {.field {tag}}.")
-      gert::git_tag_delete(tag)
+      abort(paste0("Tag ", tag, " exists, use `force = TRUE` to overwrite."))
     }
+
+    if (fledge_chatty()) cli_alert("Deleting tag {.field {tag}}.")
+    gert::git_tag_delete(tag)
+
   }
 
   if (fledge_chatty()) {
@@ -29,6 +30,7 @@ tag_version_impl <- function(force) {
     wrap = TRUE
   )
   }
+
   msg_header <- paste0(desc$get("Package"), " ", version)
   gert::git_tag_create(tag, message = paste0(msg_header, "\n\n", current_news))
 
@@ -52,4 +54,8 @@ get_current_news <- function() {
   current_news <- readLines(news_path(), n)[-1]
   current_news <- paste(current_news, collapse = "\n")
   gsub("^\n*(.*[^\n])\n*$", "\\1", current_news)
+}
+
+tag_already_exist <- function(tag) {
+  tag %in% gert::git_tag_list()$name
 }

--- a/R/tag-version.R
+++ b/R/tag-version.R
@@ -10,6 +10,7 @@ tag_version_impl <- function(force) {
   tag <- paste0("v", version)
 
   if (tag_already_exist(tag)) {
+
     if (!force) {
       if (gert::git_commit_info(tag)$id == gert::git_log(max = 1)$commit) {
         if (fledge_chatty()) {

--- a/R/tag-version.R
+++ b/R/tag-version.R
@@ -11,25 +11,28 @@ tag_version_impl <- function(force) {
 
   if (tag_already_exist(tag)) {
 
-    if (!force) {
-      if (gert::git_commit_info(tag)$id == gert::git_log(max = 1)$commit) {
-        if (fledge_chatty()) {
-          cli_alert_info("Tag {.field {tag}} exists and points to the current commit.")
-        }
+    # Tagging would do nothing as the tag points to the current commit
+    if (gert::git_commit_info(tag)$id == gert::git_log(max = 1)$commit) {
+      if (fledge_chatty()) {
+        cli_alert_info("Tag {.field {tag}} exists and points to the current commit.")
       }
+      return()
+    }
+
+    # Tagging would fail
+    if (!force) {
       abort(paste0("Tag ", tag, " exists, use `force = TRUE` to overwrite."))
     }
 
-    if (fledge_chatty()) cli_alert("Deleting tag {.field {tag}}.")
+    if (fledge_chatty()) cli_alert("Deleting existing tag {.field {tag}}.")
     gert::git_tag_delete(tag)
-
   }
 
   if (fledge_chatty()) {
-  cli_alert(
-  "Creating tag {.field {tag}} with tag message derived from {.file NEWS.md}.",
-    wrap = TRUE
-  )
+    cli_alert(
+      "Creating tag {.field {tag}} with tag message derived from {.file NEWS.md}.",
+      wrap = TRUE
+    )
   }
 
   msg_header <- paste0(desc$get("Package"), " ", version)

--- a/tests/testthat/_snaps/tag_version.md
+++ b/tests/testthat/_snaps/tag_version.md
@@ -20,13 +20,16 @@
 
 ---
 
+    Tag v0.0.0.9000 exists, use `force = TRUE` to overwrite.
+
+---
+
     Code
       tag_version(force = TRUE)
     Message <cliMessage>
-      
       -- Tagging Version --
       
-      > Deleting tag v0.0.0.9000.
+      > Deleting existing tag v0.0.0.9000.
       > Creating tag v0.0.0.9000 with tag message derived from 'NEWS.md'.
 
 ---
@@ -38,8 +41,4 @@
         name        ref                  
         <chr>       <chr>                
       1 v0.0.0.9000 refs/tags/v0.0.0.9000
-
----
-
-    Tag v0.0.0.9000 exists, use `force = TRUE` to overwrite.
 

--- a/tests/testthat/_snaps/tag_version.md
+++ b/tests/testthat/_snaps/tag_version.md
@@ -21,10 +21,25 @@
 ---
 
     Code
+      tag_version(force = TRUE)
+    Message <cliMessage>
+      
+      -- Tagging Version --
+      
+      > Deleting tag v0.0.0.9000.
+      > Creating tag v0.0.0.9000 with tag message derived from 'NEWS.md'.
+
+---
+
+    Code
       get_last_tag()[, c("name", "ref")]
     Output
       # A tibble: 1 x 2
         name        ref                  
         <chr>       <chr>                
       1 v0.0.0.9000 refs/tags/v0.0.0.9000
+
+---
+
+    Tag v0.0.0.9000 exists, use `force = TRUE` to overwrite.
 

--- a/tests/testthat/test-tag_version.R
+++ b/tests/testthat/test-tag_version.R
@@ -6,15 +6,15 @@ test_that("tag_version() works", {
     expect_snapshot(tag_version())
     expect_snapshot(get_last_tag()[, c("name", "ref")])
 
-    expect_error(tag_version(force = FALSE))
+    shut_up_fledge(expect_error(tag_version(force = FALSE)))
 
-    #expect_snapshot(tag_version(force = TRUE))
+    expect_snapshot(tag_version(force = TRUE))
     expect_snapshot(get_last_tag()[, c("name", "ref")])
 
     use_r("pof")
     gert::git_add("R/pof.R")
     gert::git_commit("* Add cool pof.")
-    #expect_snapshot_error(tag_version(force = FALSE))
+    expect_snapshot_error(tag_version(force = FALSE))
   })
 
 })

--- a/tests/testthat/test-tag_version.R
+++ b/tests/testthat/test-tag_version.R
@@ -6,15 +6,20 @@ test_that("tag_version() works", {
     expect_snapshot(tag_version())
     expect_snapshot(get_last_tag()[, c("name", "ref")])
 
-    shut_up_fledge(expect_error(tag_version(force = FALSE)))
+    # Attempting tagging again without any new commit
+    shut_up_fledge(expect_silent(tag_version()))
 
-    expect_snapshot(tag_version(force = TRUE))
-    expect_snapshot(get_last_tag()[, c("name", "ref")])
-
+    # Attempting tagging again
+    # with a new commit but same version
     use_r("pof")
     gert::git_add("R/pof.R")
     gert::git_commit("* Add cool pof.")
     expect_snapshot_error(tag_version(force = FALSE))
+
+    # Same, but forcing
+    expect_snapshot(tag_version(force = TRUE))
+    expect_snapshot(get_last_tag()[, c("name", "ref")])
+
   })
 
 })


### PR DESCRIPTION
Fix #167 

@krlmlr I might be misunderstanding something but if the tag already exists, the gert call is going to fail, no matter the commit the existing tag points to?