### PR TITLE
pkgdown: use `cynkratemplate` and add author refs

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,15 +1,36 @@
-url: https://cynkra.github.io/fledge
+url: https://fledge.cynkra.com
 
 template:
-  params:
-    bootswatch: flatly # https://bootswatch.com/flatly/
+  package: cynkratemplate
+
+destination: docs
 
 development:
   mode: auto
 
+navbar:
+  structure:
+    left: [news, articles]
+    right: [reference, projects, consulting, github]
+  components:
+    home: ~
+    reference:
+      text: REFERENCE
+      href: reference/index.html
+    projects:
+      text: PROJECTS
+      href: https://www.cynkra.com/projects.html
+    consulting:
+      text: CONSULTING
+      href: https://www.cynkra.com/consulting.html
+
 authors:
   Kirill Müller:
     href: https://krlmlr.info
+  Patrick Schratz:
+    href: https://pat-s.me
+  Maëlle Salmon:
+    href: https://masalmon.eu
 
 # Also update the table in man/rmd.fragments/functions.Rmd
 reference:

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -2,7 +2,7 @@
 title: "Using fledge"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{demo}
+  %\VignetteIndexEntry{Using fledge}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/fledge.Rmd
+++ b/vignettes/fledge.Rmd
@@ -2,7 +2,7 @@
 title: "Get started with fledge"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{fledge}
+  %\VignetteIndexEntry{Get started with fledge}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Fix #79 

I've created a CNAME entry in our DNS.

Besides, I've applied some style tweaks to {cynkratemplate} itself.