### PR TITLE
update installation instruction

### DIFF
--- a/man/rmd-fragments/setup.Rmd
+++ b/man/rmd-fragments/setup.Rmd
@@ -9,7 +9,7 @@ install.packages("fledge")
 Install from cynkra's R-universe (development version) using:
 
 ```r
-install.packages("fledge", repos = "https://cynkra.r-universe.dev")
+install.packages("fledge", repos = c("https://cynkra.r-universe.dev", "https://cloud-project.org"))
 ```
 
 Or install from GitHub (development version as well) using:

--- a/man/rmd-fragments/setup.Rmd
+++ b/man/rmd-fragments/setup.Rmd
@@ -9,7 +9,7 @@ install.packages("fledge")
 Install from cynkra's R-universe (development version) using:
 
 ```r
-install.packages("fledge", repos = c("https://cynkra.r-universe.dev", "https://cloud-project.org"))
+install.packages("fledge", repos = c("https://cynkra.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 Or install from GitHub (development version as well) using:


### PR DESCRIPTION
I attempted to install {fledge} from the R-universe, but was met with an error that I didn't have {enc} installed. Adding CRAN to the R-universe installation instructions fixed this for me.
