### PR TITLE
feat: improve bump_version() (error) messages 

### DIFF
--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -20,11 +20,11 @@
 #' Fear not, run [unbump_version()], merge that PR, run `bump_version()`.
 #'
 #' @example man/examples/bump-version.R
-bump_version <- function(which = "dev", no_change_behavior = c("bump", "noop", "fail")) {
-  check_which(which)
-
+bump_version <- function(which = c("dev", "patch", "minor", "major"), no_change_behavior = c("bump", "noop", "fail")) {
+  which <- arg_match(which)
   no_change_behavior <- arg_match(no_change_behavior)
 
   check_clean(c("DESCRIPTION", news_path))
+
   with_repo(bump_version_impl(which = which, no_change_behavior = no_change_behavior))
 }

--- a/R/api-update-version.R
+++ b/R/api-update-version.R
@@ -11,4 +11,3 @@ update_version <- function(which = c("dev", "patch", "minor", "major")) {
   update_version_impl(which)
   invisible(NULL)
 }
-

--- a/R/api-update-version.R
+++ b/R/api-update-version.R
@@ -2,6 +2,8 @@
 #'
 #' Bumps a version component and adds to `NEWS.md` and `DESCRIPTION`.
 #'
+#' @param which Component of the version number to update. Supported
+#'   values are `"dev"` (default), `"patch"`, `"minor"` and `"major"`.
 #' @example man/examples/tag-version.R
 #'
 #' @return None

--- a/R/api-update-version.R
+++ b/R/api-update-version.R
@@ -6,20 +6,9 @@
 #'
 #' @return None
 #' @export
-update_version <- function(which = "dev") {
-  check_which(which)
+update_version <- function(which = c("dev", "patch", "minor", "major")) {
+  which <- arg_match(which)
   update_version_impl(which)
   invisible(NULL)
 }
 
-#' @rdname update_version
-#' @usage NULL
-#' @aliases NULL
-check_which <- function(which) {
-  #' @param which Component of the version number to update. Supported
-  #'   values are `"dev"` (default), `"patch"`, `"minor"` and `"major"`.
-  stopifnot(
-    is.character(which), length(which) == 1, !is.na(which),
-    which %in% c("dev", "patch", "minor", "major")
-  )
-}

--- a/R/update-news.R
+++ b/R/update-news.R
@@ -24,13 +24,15 @@ collect_news <- function(messages) {
   if (length(newsworthy_items) == 0) {
     if (length(messages) <= 1) {
       newsworthy_items <- "- Same as previous version."
+      if (fledge_chatty()) cli_alert_info("Same as previous version.")
     } else {
       newsworthy_items <- "- Internal changes only."
+      if (fledge_chatty()) cli_alert_info("Internal changes only.")
     }
-  }
-
-  if (fledge_chatty()) {
-    cli_alert_success("Found {.field {length(newsworthy_items)}} NEWS-worthy entries.")
+  } else {
+    if (fledge_chatty()) {
+      cli_alert_success("Found {.field {length(newsworthy_items)}} NEWS-worthy entries.")
+    }
   }
 
   paste0(paste(newsworthy_items, collapse = "\n"), "\n\n")

--- a/R/update-news.R
+++ b/R/update-news.R
@@ -31,7 +31,9 @@ collect_news <- function(messages) {
     }
   } else {
     if (fledge_chatty()) {
-      cli_alert_success("Found {.field {length(newsworthy_items)}} NEWS-worthy entries.")
+      no <- length(newsworthy_items)
+      entry_word <- if (no == 1) "entry" else "entries"
+      cli_alert_success(sprintf("Found %s NEWS-worthy %s.", no, entry_word))
     }
   }
 

--- a/man/bump_version.Rd
+++ b/man/bump_version.Rd
@@ -5,12 +5,12 @@
 \alias{bump_version_impl}
 \title{Bump package version}
 \usage{
-bump_version(which = "dev", no_change_behavior = c("bump", "noop", "fail"))
+bump_version(
+  which = c("dev", "patch", "minor", "major"),
+  no_change_behavior = c("bump", "noop", "fail")
+)
 }
 \arguments{
-\item{which}{Component of the version number to update. Supported
-values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
-
 \item{no_change_behavior}{What to do if there was no change since the last
 version: \code{"bump"} for bump the version;
 \code{"noop"} for do nothing;

--- a/man/bump_version.Rd
+++ b/man/bump_version.Rd
@@ -11,6 +11,9 @@ bump_version(
 )
 }
 \arguments{
+\item{which}{Component of the version number to update. Supported
+values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
+
 \item{no_change_behavior}{What to do if there was no change since the last
 version: \code{"bump"} for bump the version;
 \code{"noop"} for do nothing;

--- a/man/release.Rd
+++ b/man/release.Rd
@@ -13,9 +13,6 @@ release()
 post_release()
 }
 \arguments{
-\item{which}{Component of the version number to update. Supported
-values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
-
 \item{force}{Create branches and tags even if they exist.
 Useful to recover from a previously failed attempt.}
 }

--- a/man/release.Rd
+++ b/man/release.Rd
@@ -13,6 +13,9 @@ release()
 post_release()
 }
 \arguments{
+\item{which}{Component of the version number to update. Supported
+values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
+
 \item{force}{Create branches and tags even if they exist.
 Useful to recover from a previously failed attempt.}
 }

--- a/man/update_version.Rd
+++ b/man/update_version.Rd
@@ -6,6 +6,10 @@
 \usage{
 update_version(which = c("dev", "patch", "minor", "major"))
 }
+\arguments{
+\item{which}{Component of the version number to update. Supported
+values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
+}
 \value{
 None
 }

--- a/man/update_version.Rd
+++ b/man/update_version.Rd
@@ -4,11 +4,7 @@
 \alias{update_version}
 \title{Update NEWS.md and DESCRIPTION with a new version}
 \usage{
-update_version(which = "dev")
-}
-\arguments{
-\item{which}{Component of the version number to update. Supported
-values are \code{"dev"} (default), \code{"patch"}, \code{"minor"} and \code{"major"}.}
+update_version(which = c("dev", "patch", "minor", "major"))
 }
 \value{
 None

--- a/tests/testthat/_snaps/bump_version.md
+++ b/tests/testthat/_snaps/bump_version.md
@@ -44,7 +44,7 @@
       bump_version(no_change_behavior = "bump")
     Message
       > Scraping 1 commit messages.
-      v Found 1 NEWS-worthy entries.
+      i Same as previous version.
       
       -- Updating NEWS --
       
@@ -98,4 +98,8 @@
 # bump_version() errors well for wrong arguments
 
     `no_change_behavior` must be one of "bump", "noop", or "fail", not "blabla".
+
+---
+
+    `which` must be one of "dev", "patch", "minor", or "major", not "blabla".
 

--- a/tests/testthat/_snaps/bump_version.md
+++ b/tests/testthat/_snaps/bump_version.md
@@ -4,7 +4,7 @@
       bump_version()
     Message
       > Scraping 3 commit messages.
-      v Found 1 NEWS-worthy entries.
+      v Found 1 NEWS-worthy entry.
       
       -- Updating NEWS --
       
@@ -69,7 +69,7 @@
       bump_version(which = "major")
     Message
       > Scraping 3 commit messages.
-      v Found 1 NEWS-worthy entries.
+      v Found 1 NEWS-worthy entry.
       
       -- Updating NEWS --
       

--- a/tests/testthat/_snaps/demo/demo.md
+++ b/tests/testthat/_snaps/demo/demo.md
@@ -475,7 +475,7 @@ Now that we have added bowl support to our package, it is time to bump the versi
 ```r
 fledge::bump_version()
 ## > Scraping 2 commit messages.
-## v Found 1 NEWS-worthy entries.
+## v Found 1 NEWS-worthy entry.
 ## 
 ## -- Updating NEWS --
 ## 

--- a/tests/testthat/_snaps/demo/demo.md
+++ b/tests/testthat/_snaps/demo/demo.md
@@ -540,7 +540,7 @@ Other values for the arguments are "dev" (default), "minor" and "major".
 ```r
 fledge::bump_version("patch")
 ## > Scraping 1 commit messages.
-## v Found 1 NEWS-worthy entries.
+## i Same as previous version.
 ## 
 ## -- Updating NEWS --
 ## 
@@ -642,7 +642,7 @@ The `fledge::bump_version()` takes care of it.
 ```r
 fledge::bump_version()
 ## > Scraping 1 commit messages.
-## v Found 1 NEWS-worthy entries.
+## i Same as previous version.
 ## 
 ## -- Updating NEWS --
 ## 

--- a/tests/testthat/_snaps/unbump_version.md
+++ b/tests/testthat/_snaps/unbump_version.md
@@ -4,7 +4,7 @@
       bump_version()
     Message
       > Scraping 3 commit messages.
-      v Found 1 NEWS-worthy entries.
+      v Found 1 NEWS-worthy entry.
       
       -- Updating NEWS --
       

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -70,4 +70,5 @@ test_that("bump_version() errors well for wrong arguments", {
   skip_if_not_installed("rlang", "1.0.1")
 
   expect_snapshot_error(bump_version(no_change_behavior = "blabla"))
+  expect_snapshot_error(bump_version(which = "blabla"))
 })


### PR DESCRIPTION
when `which` is wrong and when there is no newsworthy change.

Fix #325 
Fix #153 

Better for users but also for us when trying things out. :grin: 