### PR TITLE
fix: Fix conventional commit regex

### DIFF
--- a/R/update-news.R
+++ b/R/update-news.R
@@ -50,17 +50,26 @@ extract_newsworthy_items <- function(message) {
   purrr::map(message_lines, purrr::keep, ~ grepl("^[*-]", .))
 }
 
+conventional_commit_header_pattern <- function() {
+  # Type is a noun
+  # There can be a scope
+  # Compulsory space after the colon
+  "^[A-Za-z]*(\\(.*\\))?!?:[[:space:]]"
+}
+
 is_conventional_commit <- function(message) {
-  grepl(".*:", message)
+  grepl(conventional_commit_header_pattern(), message)
 }
 
 parse_conventional_commit <- function(message) {
-  header <- sub(":.*", "", message)
-  rest <- sub(sprintf("%s:", header), "", message)
+  type_matches <- regexpr(conventional_commit_header_pattern(), message)
+  header <- regmatches(message, type_matches)
+  type <- sub(":[[:space:]]$", "", header)
+  rest <- sub(header, "", message, fixed = TRUE)
   # TODO: parse body, trailer.
 
   c(
-    sprintf("## %s", header),
+    sprintf("## %s", type),
     rest
   )
 }

--- a/tests/testthat/_snaps/conventional-commits/NEWS.md
+++ b/tests/testthat/_snaps/conventional-commits/NEWS.md
@@ -1,10 +1,10 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
 ## upkeep
- update rlang usage.
+update rlang usage.
 
 ## fix
- prevent racing of requests
+prevent racing of requests
 
 Introduce a request id and a reference to latest request. Dismiss
 incoming responses other than from latest request.
@@ -15,24 +15,24 @@ obsolete now.
 Reviewed-by: Z
 Refs: #123
 ## feat(lang)
-feat(lang): add Polish language
+add Polish language
 
 ## docs
- correct spelling of CHANGELOG
+correct spelling of CHANGELOG
 
 ## chore!
- drop support for Node 6
+drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 
 ## feat(api)!
-feat(api)!: send an email to the customer when a product is shipped
+send an email to the customer when a product is shipped
 
 ## feat!
- send an email to the customer when a product is shipped
+send an email to the customer when a product is shipped
 
 ## feat
- allow provided config object to extend other configs
+allow provided config object to extend other configs
 
   BREAKING CHANGE: `extends` key in config file is now used for extending other config files
 

--- a/tests/testthat/helper-conventional-commits.R
+++ b/tests/testthat/helper-conventional-commits.R
@@ -38,7 +38,11 @@ Refs: #123
 Also tweak the CI workflow accordingly. :sweat_smile:",
 
     # Custom type
-    "upkeep: update rlang usage."
+    "upkeep: update rlang usage.",
+
+    # NOT conventional commit
+    "upkeep:update",
+    "use cool::blop()"
   )
 }
 


### PR DESCRIPTION
With the current regex, one could not run `bump_version()` on fledge's own commit log.