### PR TITLE
harvest PR title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,42 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+## fix
+Fix conventional commit regex (#329)
+
+
+## feat
+improve bump_version() (error) messages (#328)
+
+Co-authored-by: maelle <maelle@users.noreply.github.com>
+## feat
+Improve bump_version() behavior in the absence of changes (#323)
+
+Co-authored-by: Kirill Müller <krlmlr@users.noreply.github.com>
+Co-authored-by: maelle <maelle@users.noreply.github.com>
+## chore
+Turn Netlify builds off for now
+## chore
+Enable auto-style on GitHub Actions
+## feat
+New `local_test_project()` (#318)
+
+
+- Simplify test
+- Parallel tests
+## feat
+Extract conventional commit messages for the changelog
+## CHORE
+Remove testthat specialization for snapshots
+- Snapshot updates for R-CMD-check-dev ({"package":"testthat"})
+- typo fix
+- Snapshot updates for rcc-smoke (null)
+- Snapshot updates for R-CMD-check-dev ({"package":"testthat"})
+- Create and open draft release directly, without using `usethis::use_github_release()`.
+- Extract functions
+- Create tag as part of `release()`.
+- Fix `post_release()`, still need to tag released version.
+
+
 # fledge 0.1.0.9002 (2022-04-02)
 
 - `release()` no longer asks for confirmation.

--- a/R/update-news.R
+++ b/R/update-news.R
@@ -45,7 +45,6 @@ remove_housekeeping <- function(message) {
 }
 
 extract_newsworthy_items <- function(message) {
-
   if (is_merge_commit(message)) {
     title <- harvest_pr_title(message)
 


### PR DESCRIPTION
Fix #308 

WIP!

Current failure behaviour (when I turn off Wifi for instance)

```r
> update_news()
→ Scraping 23 commit messages.
! Could not get title for PR #326
! Could not get title for PR #317
! Could not get title for PR #310
! Could not get title for PR #312
! Could not get title for PR #314
! Could not get title for PR #309
! Could not get title for PR #271
! Could not get title for PR #306
! Could not get title for PR #272
! Could not get title for PR #256
! Could not get title for PR #257
✔ Found 11 NEWS-worthy entries.
```

TODOS
- [ ] Check there is a GitHub token. There is a similar check in auto.R
- [ ] Add tests (with mocking)
- [ ] Remove the demo edits of NEWS.md

To be discussed (and then TODO :-) )
- [ ] What should happen if the PR title can't be obtained from GitHub? An error? Should a placeholder be added in NEWS.md?
- [ ] As noted in https://github.com/cynkra/fledge/issues/308#issuecomment-1131726531= I feel `update_news()` should not add the items in chronological order, but rather first the non conventional commits one, then the conventional commits one, to prevent having a wrong structure. Thoughts?
