### PR TITLE
feat: New default `pre_release(which = "next")`

### DIFF
--- a/R/auto.R
+++ b/R/auto.R
@@ -30,9 +30,10 @@ pre_release <- function(which = "next", force = FALSE) {
   check_gitignore("cran-comments.md")
 
   stopifnot(which %in% c("next", "patch", "minor", "major"))
+  version_components <- get_version_components(desc$get_version())
   if (which == "next") {
-    if (patch == 99) {
-      if (minor == 99) {
+    if (version_components[["patch"]] == 99) {
+      if (version_components[["minor"]] == 99) {
         which <- "pre-major"
       } else {
         which <- "pre-minor"

--- a/R/auto.R
+++ b/R/auto.R
@@ -30,6 +30,7 @@ pre_release <- function(which = "next", force = FALSE) {
   check_gitignore("cran-comments.md")
 
   stopifnot(which %in% c("next", "patch", "minor", "major"))
+  desc <- desc::desc(file = "DESCRIPTION")
   version_components <- get_version_components(desc$get_version())
   if (which == "next") {
     if (version_components[["patch"]] == 99) {

--- a/R/auto.R
+++ b/R/auto.R
@@ -13,21 +13,34 @@
 #'
 #' @param which Component of the version number to update. Supported
 #'   values are
-#'   * `"patch"` (default),
+#'   * `"next"` (`"major"` if the current version is `x.99.99.9yz`,
+#'   `"minor"` if the current version is `x.y.99.za`,
+#'   `"patch"` otherwise),
+#'   * `"patch"`
 #'   * `"minor"`,
 #'   * `"major"`.
 #' @param force Create branches and tags even if they exist.
 #'   Useful to recover from a previously failed attempt.
 #' @name release
 #' @export
-pre_release <- function(which = "patch", force = FALSE) {
+pre_release <- function(which = "next", force = FALSE) {
   check_main_branch()
   check_only_modified(character())
 
   check_gitignore("cran-comments.md")
 
-  stopifnot(which %in% c("patch", "minor", "major"))
-
+  stopifnot(which %in% c("next", "patch", "minor", "major"))
+  if (which == "next") {
+    if (patch == 99) {
+      if (minor == 99) {
+        which <- "pre-major"
+      } else {
+        which <- "pre-minor"
+      }
+    } else {
+      which <- "patch"
+    }
+  }
   local_options(usethis.quiet = TRUE)
   with_repo(pre_release_impl(which, force))
 }

--- a/man/release.Rd
+++ b/man/release.Rd
@@ -6,7 +6,7 @@
 \alias{post_release}
 \title{Automating CRAN release}
 \usage{
-pre_release(which = "patch", force = FALSE)
+pre_release(which = "next", force = FALSE)
 
 release()
 
@@ -16,7 +16,10 @@ post_release()
 \item{which}{Component of the version number to update. Supported
 values are
 \itemize{
-\item \code{"patch"} (default),
+\item \code{"next"} (\code{"major"} if the current version is \code{x.99.99.9yz},
+\code{"minor"} if the current version is \code{x.y.99.za},
+\code{"patch"} otherwise),
+\item \code{"patch"}
 \item \code{"minor"},
 \item \code{"major"}.
 }}


### PR DESCRIPTION
Fix #521 

I did not add it to `update_version()` as in the end it seemed more logical not to.