### PR TITLE
workaround for GHA

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -10,8 +10,23 @@ on:
 jobs:
   fledge:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      deployments: read
+      id-token: read
+      issues: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      FLEDGE_GHA_CI: true
     steps:
       - uses: actions/checkout@v2
         with:

--- a/R/utils-gh-pat.R
+++ b/R/utils-gh-pat.R
@@ -44,7 +44,7 @@ v4_scopes <- function() {
 }
 
 gh_scopes <- function() {
-  if (nzchar(Sys.getenv("FLEDGE_TEST_SCOPES"))) {
+  if (nzchar(Sys.getenv("FLEDGE_TEST_SCOPES")) || nzchar(Sys.getenv("FLEDGE_GHA_CI"))) {
     v4_scopes()
   } else if (nzchar(Sys.getenv("FLEDGE_TEST_SCOPES_BAD"))) {
     "useless"


### PR DESCRIPTION
Related to https://github.com/cynkra/fledge/issues/268#issuecomment-1238910574

- Using an environment variable to assess it is run on GHA;
- Ensuring the right permissions are set on GHA. I am not 100% sure yet these are the right permissions, because the options are not the same as when creating a token via the interface.

I would like to avoid relying on a token created via the interface.

V4 scopes are needed to find issues closed by a PR. To avoid needing that one would need to tweak the merge/squash commit message defaults cf #512