### PR TITLE
feat: `update_news()` gains which argument, deprecate `update_version()`

### DIFF
--- a/R/api-update-news.R
+++ b/R/api-update-news.R
@@ -6,11 +6,22 @@
 #' @param messages A character vector of commit messages,
 #'   e.g. as in the `message` column in the return value of [get_top_level_commits()].
 #'   The default uses the top level commits since the last tag as retrieved by [get_last_tag()].
+#' @param which Component of the version number to update. Supported
+#'   values are
+#'   * `"dev"` (default),
+#'   * `"patch"`,
+#'   * `"pre-minor"` (x.y.99.9000),
+#'   * `"minor"`,
+#'   * `"pre-major"` (x.99.99.9000),
+#'   * `"major"`.
 #' @example man/examples/tag-version.R
 #'
 #' @return None
 #' @export
-update_news <- function(messages = NULL) {
+update_news <- function(messages = NULL,
+                        which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major")) {
+  which <- arg_match(which)
+
   if (is.null(messages)) {
     commits <- default_commit_range()
   } else {
@@ -20,7 +31,11 @@ update_news <- function(messages = NULL) {
     )
   }
 
-  with_repo(update_news_impl(commits))
+  local_repo()
+
+  update_news_impl(commits)
+  update_version_impl(which)
+
   invisible(NULL)
 }
 

--- a/R/api-update-version.R
+++ b/R/api-update-version.R
@@ -2,20 +2,13 @@
 #'
 #' Bumps a version component and adds to `NEWS.md` and `DESCRIPTION`.
 #'
-#' @param which Component of the version number to update. Supported
-#'   values are
-#'   * `"dev"` (default),
-#'   * `"patch"`,
-#'   * `"pre-minor"` (x.y.99.9000),
-#'   * `"minor"`,
-#'   * `"pre-major"` (x.99.99.9000),
-#'   * `"major"`.
+#' @inheritParams update_news
 #' @example man/examples/tag-version.R
 #'
 #' @return None
 #' @export
 update_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major")) {
-  which <- arg_match(which)
-  update_version_impl(which)
-  invisible(NULL)
+  # FIXME: Signal deprecation
+
+  update_news(character(), which)
 }

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -20,10 +20,8 @@ bump_version_impl <- function(which, no_change_behavior) {
       return(invisible(FALSE))
     }
   }
-  #' 1. [update_news()]
-  update_news()
-  #' 1. [update_version()], using the `which` argument
-  update_version(which = which)
+  #' 1. [update_news()], using the `which` argument
+  update_news(which = which)
   #' 1. Depending on the `which` argument:
   if (which == "dev") {
     #'     - If `"dev"`, [finalize_version()] with `push = FALSE`

--- a/R/commits.R
+++ b/R/commits.R
@@ -2,6 +2,10 @@ with_repo <- function(code) {
   withr::with_dir(usethis::proj_get(), code)
 }
 
+local_repo <- function(.local_envir = caller_env()) {
+  withr::local_dir(usethis::proj_get(), .local_envir = .local_envir)
+}
+
 get_top_level_commits_impl <- function(since) {
   commit <- gert::git_log(max = 1)$commit
 

--- a/man/bump_version.Rd
+++ b/man/bump_version.Rd
@@ -38,8 +38,7 @@ Calls the following functions:
 \enumerate{
 \item Verify that the current branch is the main branch.
 \item Check if there were changes since the last version.
-\item \code{\link[=update_news]{update_news()}}
-\item \code{\link[=update_version]{update_version()}}, using the \code{which} argument
+\item \code{\link[=update_news]{update_news()}}, using the \code{which} argument
 \item Depending on the \code{which} argument:
 \itemize{
 \item If \code{"dev"}, \code{\link[=finalize_version]{finalize_version()}} with \code{push = FALSE}

--- a/man/update_news.Rd
+++ b/man/update_news.Rd
@@ -4,12 +4,26 @@
 \alias{update_news}
 \title{Update NEWS.md with messages from top-level commits}
 \usage{
-update_news(messages = NULL)
+update_news(
+  messages = NULL,
+  which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major")
+)
 }
 \arguments{
 \item{messages}{A character vector of commit messages,
 e.g. as in the \code{message} column in the return value of \code{\link[=get_top_level_commits]{get_top_level_commits()}}.
 The default uses the top level commits since the last tag as retrieved by \code{\link[=get_last_tag]{get_last_tag()}}.}
+
+\item{which}{Component of the version number to update. Supported
+values are
+\itemize{
+\item \code{"dev"} (default),
+\item \code{"patch"},
+\item \code{"pre-minor"} (x.y.99.9000),
+\item \code{"minor"},
+\item \code{"pre-major"} (x.99.99.9000),
+\item \code{"major"}.
+}}
 }
 \value{
 None

--- a/tests/testthat/_snaps/parse-news-items/NEWS-merge.md
+++ b/tests/testthat/_snaps/parse-news-items/NEWS-merge.md
@@ -1,5 +1,7 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+# tea 0.0.0.9001
+
 - One.
 
 

--- a/tests/testthat/_snaps/parse-news-items/NEWS.md
+++ b/tests/testthat/_snaps/parse-news-items/NEWS.md
@@ -1,5 +1,7 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+# fledge 0.0.0.9001 (2023-01-23)
+
 ## Bug fixes
 
 - Prevent racing of requests.


### PR DESCRIPTION
For #588.