### PR TITLE
feat: `bump_version()` only works in interactive sessions or if `NEWS.md` has a preamble (or both)

### DIFF
--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -26,7 +26,7 @@
 bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major"), no_change_behavior = c("bump", "noop", "fail")) {
 
   is_preamble_absent <- is.null(read_news()[["preamble"]])
-  if (!rlang::is_interactive() && is_preamble_absent) {
+  if (!is_interactive() && is_preamble_absent) {
     cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
     return(invisible(FALSE))
   }

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -27,7 +27,9 @@ bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-ma
   which <- arg_match(which)
   no_change_behavior <- arg_match(no_change_behavior)
 
-  if (!fledge_is_interactive() && !read_fledgling()[["preamble_in_file"]]) {
+  fledgeling <- read_fledgling()
+
+  if (!fledge_is_interactive() && !fledgeling[["preamble_in_file"]]) {
     cli::cli_alert_info("Can't act non-interactively on a {.file NEWS.md} with no fledge-like preamble (HTML comment).")
     return(invisible(FALSE))
   }
@@ -36,5 +38,9 @@ bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-ma
 
   local_repo()
 
-  bump_version_impl(which = which, no_change_behavior = no_change_behavior)
+  bump_version_impl(
+    which = which,
+    no_change_behavior = no_change_behavior,
+    fledgeling = fledgeling
+  )
 }

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -29,7 +29,7 @@ bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-ma
   no_change_behavior <- arg_match(no_change_behavior)
 
   if (!fledge_is_interactive() && !read_fledgling()[["preamble_in_file"]]) {
-    cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
+    cli::cli_alert_info("Can't act non-interactively on a {.file NEWS.md} with no fledge-like preamble (HTML comment).")
     return(invisible(FALSE))
   }
 

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -25,14 +25,13 @@
 #' @example man/examples/bump-version.R
 bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major"), no_change_behavior = c("bump", "noop", "fail")) {
 
-  is_preamble_absent <- is.null(read_news()[["preamble"]])
-  if (!is_interactive() && is_preamble_absent) {
+  which <- arg_match(which)
+  no_change_behavior <- arg_match(no_change_behavior)
+
+  if (!is_interactive() && !read_fledgling()[["preamble_in_file"]]) {
     cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
     return(invisible(FALSE))
   }
-
-  which <- arg_match(which)
-  no_change_behavior <- arg_match(no_change_behavior)
 
   check_clean(c("DESCRIPTION", news_path))
 

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -28,7 +28,7 @@ bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-ma
   which <- arg_match(which)
   no_change_behavior <- arg_match(no_change_behavior)
 
-  if (!is_interactive() && !read_fledgling()[["preamble_in_file"]]) {
+  if (!fledge_is_interactive() && !read_fledgling()[["preamble_in_file"]]) {
     cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
     return(invisible(FALSE))
   }

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -24,7 +24,6 @@
 #'
 #' @example man/examples/bump-version.R
 bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major"), no_change_behavior = c("bump", "noop", "fail")) {
-
   which <- arg_match(which)
   no_change_behavior <- arg_match(no_change_behavior)
 

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -24,6 +24,13 @@
 #'
 #' @example man/examples/bump-version.R
 bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-major", "major"), no_change_behavior = c("bump", "noop", "fail")) {
+
+  is_preamble_absent <- is.null(read_news()[["preamble"]])
+  if (!rlang::is_interactive() && is_preamble_absent) {
+    cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
+    return(invisible())
+  }
+
   which <- arg_match(which)
   no_change_behavior <- arg_match(no_change_behavior)
 

--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -28,7 +28,7 @@ bump_version <- function(which = c("dev", "patch", "pre-minor", "minor", "pre-ma
   is_preamble_absent <- is.null(read_news()[["preamble"]])
   if (!rlang::is_interactive() && is_preamble_absent) {
     cli::cli_alert_info("Can't act non-interactively on a {.field NEWS.md} with no fledge-like preamble (HTML comment).")
-    return(invisible())
+    return(invisible(FALSE))
   }
 
   which <- arg_match(which)

--- a/R/api-update-news.R
+++ b/R/api-update-news.R
@@ -16,12 +16,14 @@
 #'   * `"minor"` (a.x.0),
 #'   * `"pre-major"` (a.99.99.9000),
 #'   * `"major"` (x.0.0).
+#' @param fledgeling Fledgeling object. For advanced use only.
 #' @example man/examples/tag-version.R
 #'
 #' @return None
 #' @export
 update_news <- function(messages = NULL,
-                        which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major", "major")) {
+                        which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major", "major"),
+                        fledgeling = NULL) {
   which <- arg_match(which)
 
   if (is.null(messages)) {
@@ -35,7 +37,11 @@ update_news <- function(messages = NULL,
 
   local_repo()
 
-  update_news_impl(commits, which)
+  update_news_impl(
+    commits = commits,
+    which = which,
+    fledgeling = fledgeling
+  )
 
   invisible(NULL)
 }

--- a/R/api-update-news.R
+++ b/R/api-update-news.R
@@ -16,14 +16,12 @@
 #'   * `"minor"` (a.x.0),
 #'   * `"pre-major"` (a.99.99.9000),
 #'   * `"major"` (x.0.0).
-#' @param fledgeling Fledgeling object. For advanced use only.
 #' @example man/examples/tag-version.R
 #'
 #' @return None
 #' @export
 update_news <- function(messages = NULL,
-                        which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major", "major"),
-                        fledgeling = NULL) {
+                        which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major", "major")) {
   which <- arg_match(which)
 
   if (is.null(messages)) {
@@ -39,8 +37,7 @@ update_news <- function(messages = NULL,
 
   update_news_impl(
     commits = commits,
-    which = which,
-    fledgeling = fledgeling
+    which = which
   )
 
   invisible(NULL)

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -1,6 +1,6 @@
 #' @rdname bump_version
 #' @usage NULL
-bump_version_impl <- function(which, no_change_behavior) {
+bump_version_impl <- function(which, no_change_behavior, fledgeling = NULL) {
   #' @description
   #' 1. Verify that the current branch is the main branch.
   check_main_branch()
@@ -21,7 +21,7 @@ bump_version_impl <- function(which, no_change_behavior) {
     }
   }
   #' 1. [update_news()], using the `which` argument
-  update_news(which = which)
+  update_news(which = which, fledgeling = fledgeling)
   #' 1. Depending on the `which` argument:
   if (which == "dev") {
     #'     - If `"dev"`, [finalize_version()] with `push = FALSE`

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -21,7 +21,7 @@ bump_version_impl <- function(which, no_change_behavior, fledgeling = NULL) {
     }
   }
   #' 1. [update_news()], using the `which` argument
-  update_news(which = which, fledgeling = fledgeling)
+  update_news_impl(default_commit_range(), which = which, fledgeling = fledgeling)
   #' 1. Depending on the `which` argument:
   if (which == "dev") {
     #'     - If `"dev"`, [finalize_version()] with `push = FALSE`

--- a/R/fledgling.R
+++ b/R/fledgling.R
@@ -156,7 +156,7 @@ read_news <- function(news_lines = NULL) {
   # create, update or re-use preamble
   is_preamble_absent <- (section_df[["start"]][[1]] == 1)
   if (is_preamble_absent) {
-    preamble <- news_preamble()
+    preamble <- NULL
   } else {
     preamble <- trim_empty_lines(news_lines[seq2(1, section_df[["start"]][[1]] - 1)])
 
@@ -177,8 +177,9 @@ read_fledgling <- function() {
   date <- read_date()
 
   news_and_preamble <- read_news()
+  news_and_preamble[["preamble"]] <- news_and_preamble[["preamble"]] %||% news_preamble()
 
-  new_fledgling(package, version, date, news_and_preamble$preamble, news_and_preamble$section_df)
+  new_fledgling(package, version, date, news_and_preamble[["preamble"]], news_and_preamble[["section_df"]])
 }
 
 trim_empty_lines <- function(x) {

--- a/R/fledgling.R
+++ b/R/fledgling.R
@@ -187,9 +187,9 @@ read_fledgling <- function() {
     package,
     version,
     date,
-    news_and_preamble[["preamble"]],
-    news_and_preamble[["section_df"]],
-    news_and_preamble[["preamble_in_file"]]
+    preamble = news_and_preamble[["preamble"]],
+    news = news_and_preamble[["section_df"]],
+    preamble_in_file = news_and_preamble[["preamble_in_file"]]
   )
 }
 

--- a/R/fledgling.R
+++ b/R/fledgling.R
@@ -9,14 +9,15 @@
 #' @param preamble The text that appears before the first section header
 #' @param news A data frame FIXME
 #' @noRd
-new_fledgling <- function(name, version, date, preamble, news) {
+new_fledgling <- function(name, version, date, preamble, news, preamble_in_file) {
   structure(
     list(
       name = name,
       version = version,
       date = date,
       preamble = preamble,
-      news = news
+      news = news,
+      preamble_in_file = preamble_in_file
     ),
     class = "fledgling"
   )
@@ -49,7 +50,8 @@ read_news <- function(news_lines = NULL) {
     return(
       list(
         section_df = NULL,
-        preamble = news_preamble()
+        preamble = news_preamble(),
+        preamble_in_file = FALSE
       )
     )
   }
@@ -156,8 +158,10 @@ read_news <- function(news_lines = NULL) {
   # create, update or re-use preamble
   is_preamble_absent <- (section_df[["start"]][[1]] == 1)
   if (is_preamble_absent) {
-    preamble <- NULL
+    preamble_in_file <- FALSE
+    preamble <- news_preamble()
   } else {
+    preamble_in_file <- TRUE
     preamble <- trim_empty_lines(news_lines[seq2(1, section_df[["start"]][[1]] - 1)])
 
     is_outdated_fledge_preamble <- (trimws(preamble) %in% old_news_preambles())
@@ -167,7 +171,8 @@ read_news <- function(news_lines = NULL) {
   }
   list(
     section_df = section_df,
-    preamble = if (!is.null(preamble)) paste(preamble, collapse = "\n")
+    preamble = if (!is.null(preamble)) paste(preamble, collapse = "\n"),
+    preamble_in_file = preamble_in_file
   )
 }
 
@@ -177,9 +182,15 @@ read_fledgling <- function() {
   date <- read_date()
 
   news_and_preamble <- read_news()
-  news_and_preamble[["preamble"]] <- news_and_preamble[["preamble"]] %||% news_preamble()
 
-  new_fledgling(package, version, date, news_and_preamble[["preamble"]], news_and_preamble[["section_df"]])
+  new_fledgling(
+    package,
+    version,
+    date,
+    news_and_preamble[["preamble"]],
+    news_and_preamble[["section_df"]],
+    news_and_preamble[["preamble_in_file"]]
+  )
 }
 
 trim_empty_lines <- function(x) {

--- a/R/repo-helper.R
+++ b/R/repo-helper.R
@@ -67,6 +67,7 @@ create_demo_project <- function(open = rlang::is_interactive(),
       {
         rlang::with_interactive(
           {
+            # we now have to create a demo project with a preambled NEWS.md for tests to pass
             usethis::use_news_md()
             news_lines <- readLines("NEWS.md")
             news_lines <- c(news_preamble(), "", news_lines)

--- a/R/repo-helper.R
+++ b/R/repo-helper.R
@@ -68,6 +68,9 @@ create_demo_project <- function(open = rlang::is_interactive(),
         rlang::with_interactive(
           {
             usethis::use_news_md()
+            news_lines <- readLines("NEWS.md")
+            news_lines <- c(news_preamble(), "", news_lines)
+            writeLines(news_lines, "NEWS.md")
           },
           value = FALSE
         )

--- a/R/update-news.R
+++ b/R/update-news.R
@@ -1,6 +1,6 @@
 # File editing ------
 
-update_news_impl <- function(commits, which) {
+update_news_impl <- function(commits, which, fledgeling = NULL) {
   news_items <- collect_news(commits)
   news_items <- normalize_news(news_items)
   news_lines <- organize_news(news_items)
@@ -10,7 +10,7 @@ update_news_impl <- function(commits, which) {
     cli_alert("Adding new entries to {.file {news_path()}}.")
   }
 
-  fledgeling <- read_fledgling()
+  fledgeling <- fledgeling %||% read_fledgling()
 
   # isTRUE() as NEWS.md can be empty
   dev_header_present <- isTRUE(

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,7 @@ is_non_empty_string <- function(x) {
   !is.na(x) && nzchar(x)
 }
 
-is_interactive <- function(x) {
+fledge_is_interactive <- function(x) {
   if (nzchar(Sys.getenv("FLEDGE.INTERACTIVE"))) {
     return(TRUE)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,6 @@ is_non_empty_string <- function(x) {
   !is.na(x) && nzchar(x)
 }
 
-
 fledge_is_interactive <- function(x) {
   if (nzchar(Sys.getenv("FLEDGE_INTERACTIVE"))) {
     return(TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,11 @@ is_any_named <- function(x) {
 is_non_empty_string <- function(x) {
   !is.na(x) && nzchar(x)
 }
+
+is_interactive <- function(x) {
+  if (nzchar(Sys.getenv("FLEDGE.INTERACTIVE"))) {
+    return(TRUE)
+  }
+
+  interactive()
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,8 +11,9 @@ is_non_empty_string <- function(x) {
   !is.na(x) && nzchar(x)
 }
 
+
 fledge_is_interactive <- function(x) {
-  if (nzchar(Sys.getenv("FLEDGE.INTERACTIVE"))) {
+  if (nzchar(Sys.getenv("FLEDGE_INTERACTIVE"))) {
     return(TRUE)
   }
 

--- a/man/update_news.Rd
+++ b/man/update_news.Rd
@@ -7,8 +7,7 @@
 update_news(
   messages = NULL,
   which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major",
-    "major"),
-  fledgeling = NULL
+    "major")
 )
 }
 \arguments{
@@ -28,8 +27,6 @@ values are
 \item \code{"pre-major"} (a.99.99.9000),
 \item \code{"major"} (x.0.0).
 }}
-
-\item{fledgeling}{Fledgeling object. For advanced use only.}
 }
 \value{
 None

--- a/man/update_news.Rd
+++ b/man/update_news.Rd
@@ -7,7 +7,8 @@
 update_news(
   messages = NULL,
   which = c("auto", "samedev", "dev", "patch", "pre-minor", "minor", "pre-major",
-    "major")
+    "major"),
+  fledgeling = NULL
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ values are
 \item \code{"pre-major"} (a.99.99.9000),
 \item \code{"major"} (x.0.0).
 }}
+
+\item{fledgeling}{Fledgeling object. For advanced use only.}
 }
 \value{
 None

--- a/tests/testthat/_snaps/bump_version.md
+++ b/tests/testthat/_snaps/bump_version.md
@@ -101,5 +101,5 @@
     Code
       bump_version()
     Message
-      i Can't act non-interactively on a NEWS.md with no fledge-like preamble (HTML comment).
+      i Can't act non-interactively on a 'NEWS.md' with no fledge-like preamble (HTML comment).
 

--- a/tests/testthat/_snaps/bump_version.md
+++ b/tests/testthat/_snaps/bump_version.md
@@ -96,3 +96,10 @@
 
     `which` must be one of "dev", "patch", "pre-minor", "minor", "pre-major", or "major", not "blabla".
 
+# bump_version() does nothing if no preamble and not interactive
+
+    Code
+      bump_version()
+    Message
+      i Can't act non-interactively on a NEWS.md with no fledge-like preamble (HTML comment).
+

--- a/tests/testthat/_snaps/fledgling.md
+++ b/tests/testthat/_snaps/fledgling.md
@@ -3,8 +3,8 @@
     {
       "section_df": [
         {
-          "start": 1,
-          "end": 6,
+          "start": 3,
+          "end": 8,
           "h2": false,
           "raw": "# fledge v2.0.0\n\n* blop\n\n* lala\n",
           "news": {
@@ -17,8 +17,8 @@
           "nickname": "NA"
         },
         {
-          "start": 7,
-          "end": 12,
+          "start": 9,
+          "end": 14,
           "h2": false,
           "raw": "# fledge v1.0.0\n\n* blip\n\n* lili\n",
           "news": {
@@ -75,8 +75,8 @@
     {
       "section_df": [
         {
-          "start": 1,
-          "end": 6,
+          "start": 3,
+          "end": 8,
           "h2": false,
           "raw": "# Changes in v2.0.0 \"Vigorous Calisthenics\"\n\n* blop\n\n* lala\n",
           "news": {
@@ -89,8 +89,8 @@
           "nickname": "\"Vigorous Calisthenics\""
         },
         {
-          "start": 7,
-          "end": 12,
+          "start": 9,
+          "end": 14,
           "h2": false,
           "raw": "# Changes in v1.0.0 \"Pumpkin Helmet\"\n\n* blip\n\n* lili\n",
           "news": {
@@ -111,8 +111,8 @@
     {
       "section_df": [
         {
-          "start": 1,
-          "end": 6,
+          "start": 3,
+          "end": 8,
           "h2": true,
           "raw": "## Changes in v2.0.0 \"Vigorous Calisthenics\"\n\n* blop\n\n* lala\n",
           "news": {
@@ -125,8 +125,8 @@
           "nickname": "\"Vigorous Calisthenics\""
         },
         {
-          "start": 7,
-          "end": 12,
+          "start": 9,
+          "end": 14,
           "h2": true,
           "raw": "## Changes in v1.0.0 \"Pumpkin Helmet\"\n\n* blip\n\n* lili\n",
           "news": {

--- a/tests/testthat/_snaps/fledgling.md
+++ b/tests/testthat/_snaps/fledgling.md
@@ -179,6 +179,7 @@
           "nickname": "NA"
         }
       ],
-      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"]
+      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"],
+      "preamble_in_file": [false]
     } 
 

--- a/tests/testthat/_snaps/fledgling.md
+++ b/tests/testthat/_snaps/fledgling.md
@@ -31,7 +31,8 @@
           "nickname": "NA"
         }
       ],
-      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"]
+      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"],
+      "preamble_in_file": [true]
     } 
 
 # read_news() works with other formats
@@ -67,7 +68,8 @@
           "nickname": "NA"
         }
       ],
-      "preamble": ["<!-- Hands off, please -->"]
+      "preamble": ["<!-- Hands off, please -->"],
+      "preamble_in_file": [true]
     } 
 
 # read_news() works with nicknames
@@ -103,7 +105,8 @@
           "nickname": "\"Pumpkin Helmet\""
         }
       ],
-      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"]
+      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"],
+      "preamble_in_file": [true]
     } 
 
 # read_news() works with h2
@@ -139,7 +142,8 @@
           "nickname": "\"Pumpkin Helmet\""
         }
       ],
-      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"]
+      "preamble": ["<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->"],
+      "preamble_in_file": [true]
     } 
 
 # read_news() works with two-lines headers

--- a/tests/testthat/_snaps/update-news.md
+++ b/tests/testthat/_snaps/update-news.md
@@ -27,6 +27,9 @@
         <named list>     <chr>         <chr>                  <chr>   <chr>   <chr>   
       1 <named list [1]> keep          tea 0.0.1 (2023-01-23) 0.0.1   (2023-~ <NA>    
       
+      $preamble_in_file
+      [1] TRUE
+      
       attr(,"class")
       [1] "fledgling"
 

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -72,3 +72,17 @@ test_that("bump_version() errors well for wrong arguments", {
   expect_snapshot_error(bump_version(no_change_behavior = "blabla"))
   expect_snapshot_error(bump_version(which = "blabla"))
 })
+
+test_that("bump_version() does nothing if no preamble and not interactive", {
+  skip_if_not_installed("rlang", "1.0.1")
+  skip_if_not_installed("testthat", "3.1.2")
+
+  withr::local_options(rlang_interactive = FALSE)
+
+  local_demo_project(quiet = TRUE)
+  # remove preamble
+  news_lines <- readLines("NEWS.md")
+  writeLines(news_lines[3:length(news_lines)], "NEWS.md")
+
+  expect_snapshot(bump_version(), variant = snapshot_variant("testthat"))
+})

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -77,8 +77,6 @@ test_that("bump_version() does nothing if no preamble and not interactive", {
   skip_if_not_installed("rlang", "1.0.1")
   skip_if_not_installed("testthat", "3.1.2")
 
-  withr::local_options(rlang_interactive = FALSE)
-
   local_demo_project(quiet = TRUE)
   # remove preamble
   news_lines <- readLines("NEWS.md")

--- a/tests/testthat/test-fledgling.R
+++ b/tests/testthat/test-fledgling.R
@@ -1,5 +1,6 @@
 test_that("read_news() works with usual format", {
   news_lines <- c(
+    news_preamble(), "",
     "# fledge v2.0.0", "",
     "* blop", "",
     "* lala", "",
@@ -27,6 +28,7 @@ test_that("read_news() works with other formats", {
 
 test_that("read_news() works with nicknames", {
   news_lines <- c(
+    news_preamble(), "",
     '# Changes in v2.0.0 "Vigorous Calisthenics"', "",
     "* blop", "",
     "* lala", "",
@@ -39,6 +41,7 @@ test_that("read_news() works with nicknames", {
 
 test_that("read_news() works with h2", {
   news_lines <- c(
+    news_preamble(), "",
     '## Changes in v2.0.0 "Vigorous Calisthenics"', "",
     "* blop", "",
     "* lala", "",
@@ -55,7 +58,7 @@ test_that("correct handling of the preamble", {
     "# fledge v2.0.0", "",
     "* blop", ""
   )
-  expect_equal(read_news(news_lines)[["preamble"]], news_preamble())
+  expect_null(read_news(news_lines)[["preamble"]])
 
   # old preamble ----
   news_lines <- c(

--- a/tests/testthat/test-fledgling.R
+++ b/tests/testthat/test-fledgling.R
@@ -58,7 +58,7 @@ test_that("correct handling of the preamble", {
     "# fledge v2.0.0", "",
     "* blop", ""
   )
-  expect_null(read_news(news_lines)[["preamble"]])
+  expect_equal(read_news(news_lines)[["preamble"]], news_preamble())
 
   # old preamble ----
   news_lines <- c(

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   error = !in_pkgdown
 )
-withr::local_options(rlang_interactive = TRUE)
+withr::local_envvar("FLEDGE.INTERACTIVE" = "yes")
 ```
 
 ## Set up the development environment

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   error = !in_pkgdown
 )
-withr::local_envvar("FLEDGE.INTERACTIVE" = "yes")
+withr::local_envvar("FLEDGE_INTERACTIVE" = "yes")
 ```
 
 ## Set up the development environment

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -28,6 +28,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   error = !in_pkgdown
 )
+withr::local_options(rlang_interactive = TRUE)
 ```
 
 ## Set up the development environment


### PR DESCRIPTION
Fix #596