### PR TITLE
fix: better error message when duplicate version name

### DIFF
--- a/R/fledgling.R
+++ b/R/fledgling.R
@@ -77,6 +77,17 @@ read_news <- function(news_lines = NULL) {
     section_start
   }
 
+  duplicate_version_names_present <- anyDuplicated(names(news))
+  if (duplicate_version_names_present) {
+    duplicated_version_names <- toString(names(news)[duplicated(names(news))])
+    cli::cli_abort(
+      c(
+        "Can't deal with duplicate version names: {duplicated_version_names}.",
+        i = "Fix the duplication then retry."
+      )
+    )
+  }
+
   starts <- purrr::map_int(names(news), get_section_start, news_lines)
 
   ends <- if (length(starts) == 1) {

--- a/tests/testthat/_snaps/fledgling.md
+++ b/tests/testthat/_snaps/fledgling.md
@@ -183,3 +183,12 @@
       "preamble_in_file": [false]
     } 
 
+# read_news() reports duplicated version names
+
+    Code
+      read_news(news_lines)
+    Condition
+      Error in `read_news()`:
+      ! Can't deal with duplicate version names: fledge v2.0.0.
+      i Fix the duplication then retry.
+

--- a/tests/testthat/test-fledgling.R
+++ b/tests/testthat/test-fledgling.R
@@ -98,3 +98,16 @@ test_that("read_news() works with two-lines headers", {
   )
   expect_snapshot_tibble(read_news(news_lines))
 })
+
+test_that("read_news() reports duplicated version names", {
+  news_lines <- c(
+    "fledge v2.0.0",
+    "=============", "",
+    "* blop", "",
+    "* lala", "",
+    "# fledge v2.0.0", "",
+    "* blip", "",
+    "* lili", ""
+  )
+  expect_snapshot(read_news(news_lines), error = TRUE)
+})


### PR DESCRIPTION
Fix #672 

```r
> withr::with_dir("../tic", read_fledgling())
Error in `read_news()` at fledge/R/fledgling.R:195:2:
! Can't deal with duplicate version names: tic 0.2.13.9011.
ℹ Fix the duplication then retry.
Backtrace:
 1. withr::with_dir("../tic", read_fledgling())
 3. fledge:::read_fledgling()
 4. fledge:::read_news()
      at fledge/R/fledgling.R:195:2
```

@pat-s