### PR TITLE
feat: Leave empty line between NEWS entries

### DIFF
--- a/tests/testthat/_snaps/parse-news-items/NEWS.md
+++ b/tests/testthat/_snaps/parse-news-items/NEWS.md
@@ -1,17 +1,27 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# fledge 0.0.1 (2023-01-23)
+# fledge 0.0.1
+
+## Breaking changes
+
+- Breaking change: drop support for Node 6.
+  BREAKING CHANGE: use JavaScript features not available in Node 6.
+
+### api
+
+- Breaking change: send an email to the customer when a product is shipped.
+
+## upkeep
+
+- Update rlang usage.
 
 ## Bug fixes
 
 - Prevent racing of requests.
-
   Introduce a request id and a reference to latest request. Dismiss
   incoming responses other than from latest request.
-
   Remove timeouts which were used to mitigate the racing issue but are
   obsolete now.
-
   Reviewed-by: Z
   Refs: #123
 
@@ -25,35 +35,19 @@
 
 - Breaking change: send an email to the customer when a product is shipped.
 
-- Breaking change: send an email to the customer when a product is shipped.
-
 - Allow provided config object to extend other configs.
-
   BREAKING CHANGE: `extends` key in config file is now used for extending other config files
 
 ## Chore
 
 - Breaking change: drop support for Node 6.
-
   BREAKING CHANGE: use JavaScript features not available in Node 6.
 
 ## Documentation
 
 - Correct spelling of CHANGELOG.
 
-## Breaking changes
+## Uncategorized
 
-- Breaking change: drop support for Node 6.
-
-  BREAKING CHANGE: use JavaScript features not available in Node 6.
-
-### api
-
-- Breaking change: send an email to the customer when a product is shipped.
-
-- Breaking change: send an email to the customer when a product is shipped.
-
-## upkeep
-
-- Update rlang usage.
+- Added a `NEWS.md` file to track changes to the package.
 

--- a/tests/testthat/_snaps/update-news/samedev-updated.md
+++ b/tests/testthat/_snaps/update-news/samedev-updated.md
@@ -9,6 +9,7 @@
 ## Features
 
 - Neat helper.
+
 - New stuff.
 
 

--- a/tests/testthat/helper-quiet.R
+++ b/tests/testthat/helper-quiet.R
@@ -1,6 +1,10 @@
 shut_up_fledge <- function(code) {
   withr::with_options(
-    new = list("fledge.quiet" = TRUE, "usethis.quiet" = TRUE),
+    new = list(
+      "fledge.quiet" = TRUE,
+      "usethis.quiet" = TRUE,
+      "rlang_interactive" = FALSE
+    ),
     code
   )
 }

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -3,14 +3,17 @@ test_that("Can parse conventional commits", {
   withr::local_options(usethis.quiet = TRUE)
 
   repo <- withr::local_tempdir()
+  local_options(repos = NULL)
   withr::local_dir(repo)
 
   create_cc_repo()
   messages <- get_top_level_commits_impl(since = NULL)[["message"]]
 
-  usethis::with_project(
-    repo,
-    usethis::use_description(fields = list(Package = "fledge")),
+  usethis::with_project(repo,
+    {
+      usethis::use_description(fields = list(Package = "fledge"))
+      usethis::use_news_md()
+    },
     force = TRUE
   )
 


### PR DESCRIPTION
For some reason, this adds spurious newlines. @maelle: can you please take a look?

Moving forward, should we replace pandoc by something lighter-weight? We really only need to detect `/^#+/` because we assume that nobody will write unindented code blocks or similar that contain this pattern. I'm willing to live with any limitations that will bring.

With pandoc, tests are running very slow too.