### PR TITLE
tests: add a function to help run the tests without losing one's current dir

### DIFF
--- a/tests/testthat/helper-cleanup.R
+++ b/tests/testthat/helper-cleanup.R
@@ -1,0 +1,9 @@
+# to use when you run a test interactively
+# and have changed the local directory
+# and local usethis project
+
+back_to_start <- function() {
+  current_dev_project <- rstudioapi::getActiveProject()
+  setwd(current_dev_project)
+  usethis::proj_set(current_dev_project)
+}


### PR DESCRIPTION
Part of #714

> there's a tension between testing and debugging tests regarding the use of local_ functions in tests: changing the local directory makes it hard, well clumsy, to run tests interactively.