### PR TITLE
tests: clean up, simplify tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     purrr (>= 0.3.2),
     rematch2,
     rlang (>= 0.4.12),
+    testthat (>= 3.1.10),
     tibble,
     usethis (>= 2.1.5),
     whoami,
@@ -54,14 +55,12 @@ Suggests:
     httptest2,
     jsonlite,
     knitr,
-    mockery,
     parsedate,
     pkgbuild,
     pkgload,
     rmarkdown,
     rstudioapi,
     rversions,
-    testthat (>= 3.0.0),
     vctrs,
     withr
 Config/Needs/readme: r-lib/downlit@f-readme-document

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,6 @@ Imports:
     purrr (>= 0.3.2),
     rematch2,
     rlang (>= 0.4.12),
-    testthat (>= 3.1.10),
     tibble,
     usethis (>= 2.1.5),
     whoami,
@@ -61,6 +60,7 @@ Suggests:
     rmarkdown,
     rstudioapi,
     rversions,
+    testthat (>= 3.1.10),
     vctrs,
     withr
 Config/Needs/readme: r-lib/downlit@f-readme-document

--- a/R/auto.R
+++ b/R/auto.R
@@ -206,7 +206,7 @@ update_cran_comments <- function() {
 }
 
 get_crp_date <- function() {
-  cmt <- gh::gh("/repos/eddelbuettel/crp/commits")[[1]]
+  cmt <- gh("/repos/eddelbuettel/crp/commits")[[1]]
   date <- cmt$commit$committer$date
   as.Date(date)
 }
@@ -396,7 +396,7 @@ create_github_release <- function() {
   slug <- github_slug()
   tag <- get_tag_info()
 
-  out <- gh::gh(
+  out <- gh(
     glue("POST /repos/{slug}/releases"),
     tag_name = tag$name,
     name = tag$header,
@@ -453,7 +453,7 @@ is_ignored <- function(path) {
 }
 
 create_pull_request <- function(release_branch, main_branch, remote_name, force) {
-  # FIXME: Use gh::gh() to determine if we need to create the pull request
+  # FIXME: Use gh() to determine if we need to create the pull request
   create <- TRUE
 
   if (create) {
@@ -462,7 +462,7 @@ create_pull_request <- function(release_branch, main_branch, remote_name, force)
     template_path <- system.file("templates", "pr.md", package = "fledge")
     body <- glue_collapse(readLines(template_path), sep = "\n")
 
-    pr <- gh::gh(
+    pr <- gh(
       "POST /repos/:owner/:repo/pulls",
       owner = info$owner$login,
       repo = info$name,
@@ -479,7 +479,7 @@ create_pull_request <- function(release_branch, main_branch, remote_name, force)
     )
 
     ## ensure that label exists ----
-    labels <- gh::gh(
+    labels <- gh(
       "GET /repos/:owner/:repo/labels",
       owner = info$owner$login,
       repo = info$name
@@ -489,7 +489,7 @@ create_pull_request <- function(release_branch, main_branch, remote_name, force)
     no_cran_release_label <- (length(cran_release_label) == 0)
     if (no_cran_release_label) {
       cran_release_label <- "CRAN release :station:"
-      gh::gh(
+      gh(
         "POST /repos/:owner/:repo/labels",
         owner = info[["owner"]][["login"]],
         repo = info[["name"]],
@@ -499,7 +499,7 @@ create_pull_request <- function(release_branch, main_branch, remote_name, force)
     }
 
     ## add label to PR ----
-    gh::gh(
+    gh(
       "PATCH /repos/:owner/:repo/issues/:issue_number",
       owner = info[["owner"]][["login"]],
       repo = info[["name"]],
@@ -517,7 +517,7 @@ release_after_cran_built_binaries <- function() {
   remote <- "origin"
   github_info <- github_info(remote)
 
-  prs <- gh::gh(
+  prs <- gh(
     "GET /repos/:owner/:repo/pulls",
     owner = github_info[["owner"]][["login"]],
     repo = github_info[["name"]],

--- a/R/gh-helpers.R
+++ b/R/gh-helpers.R
@@ -29,6 +29,6 @@ extract_repo <- function(url) {
 }
 
 get_repo_data <- function(repo) {
-  req <- gh::gh("/repos/:repo", repo = repo)
+  req <- gh("/repos/:repo", repo = repo)
   return(req)
 }

--- a/R/parse-news-items.R
+++ b/R/parse-news-items.R
@@ -279,7 +279,7 @@ harvest_pr_data <- function(message) {
       {
         # suppressMessages() for quiet mocking
         suppressMessages(
-          gh::gh(glue("GET /repos/{slug}/pulls/{pr_number}"))
+          gh(glue("GET /repos/{slug}/pulls/{pr_number}"))
         )
       },
       error = function(e) {

--- a/R/parse-news-items.R
+++ b/R/parse-news-items.R
@@ -360,10 +360,10 @@ has_internet <- function() {
   if (!rlang::is_installed("curl")) {
     return(FALSE)
   }
-  if (nzchar(Sys.getenv("YES_INTERNET_TEST_FLEDGE"))) {
+  if (nzchar(Sys.getenv("FLEDGE_YES_INTERNET_TEST"))) {
     return(TRUE)
   }
-  if (nzchar(Sys.getenv("NO_INTERNET_TEST_FLEDGE"))) {
+  if (nzchar(Sys.getenv("FLEDGE_NO_INTERNET_TEST"))) {
     return(FALSE)
   }
   curl::has_internet()

--- a/R/repo-helper.R
+++ b/R/repo-helper.R
@@ -124,10 +124,9 @@ with_demo_project <- function(code, dir = NULL, news = TRUE, quiet = FALSE) {
 local_demo_project <- function(dir = NULL,
                                news = TRUE,
                                quiet = FALSE,
-                              .local_envir = parent.frame()) {
-
-    dir <- dir %||%
-      withr::local_tempdir(pattern = "fledge", .local_envir = .local_envir)
+                               .local_envir = parent.frame()) {
+  dir <- dir %||%
+    withr::local_tempdir(pattern = "fledge", .local_envir = .local_envir)
 
   if (!dir.exists(dir)) {
     cli::cli_abort(c(x = "Can't find the directory {.file {dir}}."))

--- a/R/utils-gh.R
+++ b/R/utils-gh.R
@@ -1,0 +1,3 @@
+gh <- function(...) {
+  gh::gh(...)
+}

--- a/man/create_demo_project.Rd
+++ b/man/create_demo_project.Rd
@@ -11,8 +11,7 @@ create_demo_project(
   email = NULL,
   date = "2021-09-27",
   dir = file.path(tempdir(), "fledge"),
-  news = FALSE,
-  dev_md = FALSE
+  news = FALSE
 )
 }
 \arguments{
@@ -29,9 +28,6 @@ create_demo_project(
 \item{dir}{Directory within which to create the mock package folder.}
 
 \item{news}{If TRUE, create a NEWS.md file.}
-
-\item{dev_md}{Whether to use "(development version)" (with \code{dev_md = TRUE}) or the current version
-number, in the first NEWS.md header.}
 }
 \value{
 The path to the newly created mock package.

--- a/tests/testthat/_snaps/bump_version.md
+++ b/tests/testthat/_snaps/bump_version.md
@@ -23,8 +23,12 @@
 
 ---
 
-    x No change since last version.
-    i Use `no_change_behavior = "bump"` to force a version bump, or `no_change_behavior = "noop"` to do nothing.
+    Code
+      bump_version(no_change_behavior = "fail")
+    Condition
+      Error in `bump_version_impl()`:
+      x No change since last version.
+      i Use `no_change_behavior = "bump"` to force a version bump, or `no_change_behavior = "noop"` to do nothing.
 
 ---
 
@@ -80,21 +84,37 @@
 
 # bump_version() errors informatively for forbidden notifications
 
-    x Unindexed change(s) in `DESCRIPTION`.
-    i Commit the change(s) before running any fledge function again.
+    Code
+      bump_version()
+    Condition
+      Error in `check_clean()`:
+      x Unindexed change(s) in `DESCRIPTION`.
+      i Commit the change(s) before running any fledge function again.
 
 # bump_version() errors informatively for wrong branch
 
-    x Must be on the main branch ("main") for running fledge functions.
-    i Currently on branch "bla".
+    Code
+      bump_version()
+    Condition
+      Error in `check_main_branch()`:
+      x Must be on the main branch ("main") for running fledge functions.
+      i Currently on branch "bla".
 
 # bump_version() errors well for wrong arguments
 
-    `no_change_behavior` must be one of "bump", "noop", or "fail", not "blabla".
+    Code
+      bump_version(no_change_behavior = "blabla")
+    Condition
+      Error in `bump_version()`:
+      ! `no_change_behavior` must be one of "bump", "noop", or "fail", not "blabla".
 
 ---
 
-    `which` must be one of "dev", "patch", "pre-minor", "minor", "pre-major", or "major", not "blabla".
+    Code
+      bump_version(which = "blabla")
+    Condition
+      Error in `bump_version()`:
+      ! `which` must be one of "dev", "patch", "pre-minor", "minor", "pre-major", or "major", not "blabla".
 
 # bump_version() does nothing if no preamble and not interactive
 

--- a/tests/testthat/_snaps/parse-news-items.md
+++ b/tests/testthat/_snaps/parse-news-items.md
@@ -80,8 +80,13 @@
 
 # Can parse PR merge commits - PAT absence
 
-    x Can't find a GitHub Personal Access Token (PAT).
-    i See for instance `?gh::gh_token` or <https://usethis.r-lib.org/reference/github-token.html>
+    Code
+      extract_newsworthy_items(
+        "Merge pull request #332 from cynkra/conventional-parsing")
+    Condition
+      Error in `check_gh_pat()`:
+      x Can't find a GitHub Personal Access Token (PAT).
+      i See for instance `?gh::gh_token` or <https://usethis.r-lib.org/reference/github-token.html>
 
 # Can parse PR merge commits - other error
 

--- a/tests/testthat/_snaps/tag_version.md
+++ b/tests/testthat/_snaps/tag_version.md
@@ -17,7 +17,11 @@
 
 ---
 
-    Tag "v0.0.0.9000" exists, use `force = TRUE` to overwrite.
+    Code
+      shut_up_fledge(tag_version(force = FALSE))
+    Condition
+      Error in `tag_version_impl()`:
+      ! Tag "v0.0.0.9000" exists, use `force = TRUE` to overwrite.
 
 ---
 

--- a/tests/testthat/_snaps/with_demo_project.md
+++ b/tests/testthat/_snaps/with_demo_project.md
@@ -1,4 +1,8 @@
 # with_demo_project errors informatively
 
-    x Can't find the directory 'unexisting-dir'.
+    Code
+      with_demo_project(1 + 1, dir = "unexisting-dir")
+    Condition
+      Error in `local_demo_project()`:
+      x Can't find the directory 'unexisting-dir'.
 

--- a/tests/testthat/helper-conventional-commits.R
+++ b/tests/testthat/helper-conventional-commits.R
@@ -46,7 +46,7 @@ Also tweak the CI workflow accordingly. :sweat_smile:",
   )
 }
 
-sort_of_commit <- function(commit_message, repo) {
+sort_of_commit <- function(commit_message, repo = ".") {
   file <- digest::sha1(commit_message)
   file.create(file.path(repo, file))
   gert::git_add(file, repo = repo)

--- a/tests/testthat/helper-remote.R
+++ b/tests/testthat/helper-remote.R
@@ -1,5 +1,4 @@
 create_remote <- function(tempdir_remote) {
-
   gert::git_init(tempdir_remote, bare = TRUE)
 
   current_remotes <- gert::git_remote_list()
@@ -18,7 +17,6 @@ create_remote <- function(tempdir_remote) {
 }
 
 show_tags <- function(remote_url) {
-
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
 
   withr::with_dir(tempdir_remote, {

--- a/tests/testthat/helper-remote.R
+++ b/tests/testthat/helper-remote.R
@@ -1,24 +1,38 @@
-create_remote <- function() {
-  # assuming this is a temporary directory :-)
-  parent_dir <- dirname(getwd())
-  dir.create(file.path(parent_dir, "remote"))
-  gert::git_init(file.path(parent_dir, "remote"), bare = TRUE)
-  remote_url <- file.path(parent_dir, "remote")
-  gert::git_remote_add(remote_url, name = "origin")
+create_remote <- function(tempdir_remote) {
+
+  gert::git_init(tempdir_remote, bare = TRUE)
+
+  current_remotes <- gert::git_remote_list()
+  origin_exists <- "origin" %in% current_remotes[["name"]]
+  if (origin_exists) {
+    cli::cli_abort(c(
+      "Found an origin, we're in {getwd()}, was this expected?",
+      i = "Did you forget to set up a local toy repo?"
+    ))
+  }
+
+  gert::git_remote_add(tempdir_remote, name = "origin")
   gert::git_push(remote = "origin")
-  remote_url
+
+  tempdir_remote
 }
 
 show_tags <- function(remote_url) {
+
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
+
   withr::with_dir(tempdir_remote, {
-    gert::git_clone(remote_url)
+    gert::git_clone(remote_url, path = "remote")
     gert::git_tag_list(repo = "remote")[, c("name", "ref")]
   })
 }
+
 show_files <- function(remote_url) {
   if (!gert::user_is_configured()) {
-    usethis::use_git_config(user.name = "Jane Doe", user.email = "jane@example.com")
+    usethis::use_git_config(
+      user.name = "Jane Doe",
+      user.email = "jane@example.com"
+    )
   }
 
   git_config <- gert::git_config_global()
@@ -28,7 +42,7 @@ show_files <- function(remote_url) {
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
   withr::with_dir(tempdir_remote, {
-    gert::git_clone(remote_url)
+    gert::git_clone(remote_url, path = "remote")
     suppressMessages(gert::git_branch_checkout("main", force = TRUE, repo = "remote"))
     fs::dir_ls("remote", recurse = TRUE)
   })

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -1,52 +1,56 @@
 test_that("bump_version() works -- dev", {
-  skip_if_not_installed("rlang", "1.0.1")
-  skip_if_not_installed("testthat", "3.1.2")
 
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
   create_remote(tempdir_remote)
+
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
+
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9000")
-  expect_snapshot(bump_version(), variant = snapshot_variant("testthat"))
+
+  expect_snapshot(bump_version())
+
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9001")
-  expect_equal(get_last_tag()$name, "v0.0.0.9001")
+  expect_equal(get_last_tag()[["name"]], "v0.0.0.9001")
   expect_snapshot_file("NEWS.md", compare = compare_file_text)
 
-  ## no changes
-  expect_snapshot_error(bump_version(no_change_behavior = "fail"), variant = snapshot_variant("testthat"))
-  expect_snapshot(bump_version(no_change_behavior = "noop"), variant = snapshot_variant("testthat"))
+  ## no changes ----
+  expect_snapshot_error(bump_version(no_change_behavior = "fail"))
+
+  expect_snapshot(bump_version(no_change_behavior = "noop"))
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9001")
-  expect_equal(get_last_tag()$name, "v0.0.0.9001")
-  expect_snapshot(bump_version(no_change_behavior = "bump"), variant = snapshot_variant("testthat"))
+  expect_equal(get_last_tag()[["name"]], "v0.0.0.9001")
+
+  expect_snapshot(bump_version(no_change_behavior = "bump"))
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9002")
-  expect_equal(get_last_tag()$name, "v0.0.0.9002")
+  expect_equal(get_last_tag()[["name"]], "v0.0.0.9002")
   expect_snapshot_file("NEWS.md", "NEWS2.md", compare = compare_file_text)
 })
 
 test_that("bump_version() works -- not dev", {
-  skip_if_not_installed("rlang", "1.0.1")
-  skip_if_not_installed("testthat", "3.1.2")
 
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
   create_remote(tempdir_remote)
+
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
+
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9000")
-  expect_snapshot(bump_version(which = "major"), variant = snapshot_variant("testthat"))
+
+  expect_snapshot(bump_version(which = "major"))
   expect_equal(as.character(desc::desc_get_version()), "1.0.0")
   expect_snapshot_file("NEWS.md", "NEWS-nondev.md", compare = compare_file_text)
 })
 
 test_that("bump_version() errors informatively for forbidden notifications", {
-  skip_if_not_installed("rlang", "1.0.1")
 
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
@@ -54,12 +58,13 @@ test_that("bump_version() errors informatively for forbidden notifications", {
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
+
   desc::desc_set_dep("bla")
+
   expect_snapshot_error(bump_version())
 })
 
 test_that("bump_version() errors informatively for wrong branch", {
-  skip_if_not_installed("rlang", "1.0.1")
 
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
@@ -67,28 +72,28 @@ test_that("bump_version() errors informatively for wrong branch", {
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
-  gert::git_branch_create("bla")
+
+  gert::git_branch_create("bla", checkout = TRUE)
+
   expect_snapshot_error(bump_version())
 })
 
 
 test_that("bump_version() errors well for wrong arguments", {
-  skip_if_not_installed("rlang", "1.0.1")
 
   expect_snapshot_error(bump_version(no_change_behavior = "blabla"))
+
   expect_snapshot_error(bump_version(which = "blabla"))
 })
 
 test_that("bump_version() does nothing if no preamble and not interactive", {
-  skip_if_not_installed("rlang", "1.0.1")
-  skip_if_not_installed("testthat", "3.1.2")
 
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
-  # remove preamble
   news_lines <- readLines("NEWS.md")
-  writeLines(news_lines[3:length(news_lines)], "NEWS.md")
+  preamble_lines <- 1:2
+  brio::write_lines(news_lines[-preamble_lines], "NEWS.md")
 
-  expect_snapshot(bump_version(), variant = snapshot_variant("testthat"))
+  expect_snapshot(bump_version())
 })

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -5,7 +5,8 @@ test_that("bump_version() works -- dev", {
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
-  create_remote()
+  tempdir_remote <- withr::local_tempdir(pattern = "remote")
+  create_remote(tempdir_remote)
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
@@ -33,7 +34,8 @@ test_that("bump_version() works -- not dev", {
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
-  create_remote()
+  tempdir_remote <- withr::local_tempdir(pattern = "remote")
+  create_remote(tempdir_remote)
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -72,7 +72,6 @@ test_that("bump_version() errors informatively for wrong branch", {
 
 
 test_that("bump_version() errors well for wrong arguments", {
-
   expect_snapshot(error = TRUE, bump_version(no_change_behavior = "blabla"))
 
   expect_snapshot(error = TRUE, bump_version(which = "blabla"))

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -1,6 +1,5 @@
 test_that("bump_version() works -- dev", {
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
@@ -33,7 +32,6 @@ test_that("bump_version() works -- dev", {
 
 test_that("bump_version() works -- not dev", {
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
@@ -52,7 +50,6 @@ test_that("bump_version() works -- not dev", {
 
 test_that("bump_version() errors informatively for forbidden notifications", {
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -66,7 +63,6 @@ test_that("bump_version() errors informatively for forbidden notifications", {
 
 test_that("bump_version() errors informatively for wrong branch", {
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -88,7 +84,6 @@ test_that("bump_version() errors well for wrong arguments", {
 
 test_that("bump_version() does nothing if no preamble and not interactive", {
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   news_lines <- readLines("NEWS.md")

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -17,7 +17,7 @@ test_that("bump_version() works -- dev", {
   expect_snapshot_file("NEWS.md", compare = compare_file_text)
 
   ## no changes ----
-  expect_snapshot_error(bump_version(no_change_behavior = "fail"))
+  expect_snapshot(error = TRUE, bump_version(no_change_behavior = "fail"))
 
   expect_snapshot(bump_version(no_change_behavior = "noop"))
   expect_equal(as.character(desc::desc_get_version()), "0.0.0.9001")
@@ -55,7 +55,7 @@ test_that("bump_version() errors informatively for forbidden notifications", {
 
   desc::desc_set_dep("bla")
 
-  expect_snapshot_error(bump_version())
+  expect_snapshot(error = TRUE, bump_version())
 })
 
 test_that("bump_version() errors informatively for wrong branch", {
@@ -67,14 +67,15 @@ test_that("bump_version() errors informatively for wrong branch", {
 
   gert::git_branch_create("bla", checkout = TRUE)
 
-  expect_snapshot_error(bump_version())
+  expect_snapshot(error = TRUE, bump_version())
 })
 
 
 test_that("bump_version() errors well for wrong arguments", {
-  expect_snapshot_error(bump_version(no_change_behavior = "blabla"))
 
-  expect_snapshot_error(bump_version(which = "blabla"))
+  expect_snapshot(error = TRUE, bump_version(no_change_behavior = "blabla"))
+
+  expect_snapshot(error = TRUE, bump_version(which = "blabla"))
 })
 
 test_that("bump_version() does nothing if no preamble and not interactive", {

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -1,5 +1,4 @@
 test_that("bump_version() works -- dev", {
-
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
@@ -31,7 +30,6 @@ test_that("bump_version() works -- dev", {
 })
 
 test_that("bump_version() works -- not dev", {
-
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
@@ -49,7 +47,6 @@ test_that("bump_version() works -- not dev", {
 })
 
 test_that("bump_version() errors informatively for forbidden notifications", {
-
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -62,7 +59,6 @@ test_that("bump_version() errors informatively for forbidden notifications", {
 })
 
 test_that("bump_version() errors informatively for wrong branch", {
-
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -76,14 +72,12 @@ test_that("bump_version() errors informatively for wrong branch", {
 
 
 test_that("bump_version() errors well for wrong arguments", {
-
   expect_snapshot_error(bump_version(no_change_behavior = "blabla"))
 
   expect_snapshot_error(bump_version(which = "blabla"))
 })
 
 test_that("bump_version() does nothing if no preamble and not interactive", {
-
   local_demo_project(quiet = TRUE)
 
   news_lines <- readLines("NEWS.md")

--- a/tests/testthat/test-finalize-version.R
+++ b/tests/testthat/test-finalize-version.R
@@ -26,8 +26,8 @@ test_that("finalize_version(push = TRUE)", {
   local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
-
-  remote_url <- create_remote()
+  tempdir_remote <- withr::local_tempdir(pattern = "remote")
+  remote_url <- create_remote(tempdir_remote)
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Ad cool bla.")

--- a/tests/testthat/test-finalize-version.R
+++ b/tests/testthat/test-finalize-version.R
@@ -1,5 +1,4 @@
 test_that("finalize_version(push = FALSE)", {
-
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -21,7 +20,6 @@ test_that("finalize_version(push = FALSE)", {
 })
 
 test_that("finalize_version(push = TRUE)", {
-
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")

--- a/tests/testthat/test-finalize-version.R
+++ b/tests/testthat/test-finalize-version.R
@@ -1,45 +1,50 @@
 test_that("finalize_version(push = FALSE)", {
-  skip_if_not_installed("rlang", "1.0.1")
-  skip_if_not_installed("testthat", "3.1.2")
 
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Ad cool bla.")
+
   shut_up_fledge(bump_version())
 
-  news <- readLines("NEWS.md")
+  news <- brio::read_lines("NEWS.md")
   news <- sub("Ad cool", "Add cool", news)
-  writeLines(news, "NEWS.md")
+  brio::write_lines(news, "NEWS.md")
 
-  expect_snapshot(finalize_version(push = FALSE), variant = snapshot_variant("testthat"))
+  expect_snapshot(finalize_version(push = FALSE))
 
-  expect_snapshot_file("NEWS.md", "NEWS-push-false.md", compare = compare_file_text)
+  expect_snapshot_file(
+    "NEWS.md", "NEWS-push-false.md",
+    compare = compare_file_text
+  )
 })
 
 test_that("finalize_version(push = TRUE)", {
-  skip_if_not_installed("rlang", "1.0.1")
-  skip_if_not_installed("testthat", "3.1.2")
 
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
   remote_url <- create_remote(tempdir_remote)
+
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Ad cool bla.")
+
   shut_up_fledge(bump_version())
 
-  news <- readLines("NEWS.md")
+  news <- brio::read_lines("NEWS.md")
   news <- sub("Ad cool", "Add cool", news)
-  writeLines(news, "NEWS.md")
+  brio::write_lines(news, "NEWS.md")
 
-  expect_snapshot(variant = snapshot_variant("testthat"), {
+  expect_snapshot({
     finalize_version(push = TRUE)
     show_tags(remote_url)
     show_files(remote_url)
   })
 
-  expect_snapshot_file("NEWS.md", "NEWS-push-true.md", compare = compare_file_text)
+  expect_snapshot_file(
+    "NEWS.md", "NEWS-push-true.md",
+    compare = compare_file_text
+  )
 })

--- a/tests/testthat/test-finalize-version.R
+++ b/tests/testthat/test-finalize-version.R
@@ -2,7 +2,6 @@ test_that("finalize_version(push = FALSE)", {
   skip_if_not_installed("rlang", "1.0.1")
   skip_if_not_installed("testthat", "3.1.2")
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   use_r("bla")
@@ -23,7 +22,6 @@ test_that("finalize_version(push = TRUE)", {
   skip_if_not_installed("rlang", "1.0.1")
   skip_if_not_installed("testthat", "3.1.2")
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   tempdir_remote <- withr::local_tempdir(pattern = "remote")

--- a/tests/testthat/test-fledgling.R
+++ b/tests/testthat/test-fledgling.R
@@ -52,31 +52,33 @@ test_that("read_news() works with h2", {
   expect_snapshot_tibble(read_news(news_lines))
 })
 
-test_that("correct handling of the preamble", {
-  # no preamble ----
+test_that("correct handling of no preamble", {
   news_lines <- c(
     "# fledge v2.0.0", "",
     "* blop", ""
   )
   expect_equal(read_news(news_lines)[["preamble"]], news_preamble())
+})
 
-  # old preamble ----
+test_that("correct handling of old preamble", {
   news_lines <- c(
     "<!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->", "",
     "# fledge v2.0.0", "",
     "* blop", ""
   )
   expect_equal(read_news(news_lines)[["preamble"]], news_preamble())
+})
 
-  # current preamble ----
+test_that("correct handling of current preamble", {
   news_lines <- c(
     news_preamble(), "",
     "# fledge v2.0.0", "",
     "* blop", ""
   )
   expect_equal(read_news(news_lines)[["preamble"]], news_preamble())
+})
 
-  # custom preamble ----
+test_that("correct handling of custom preamble", {
   fancy <- "<!-- NEWS.md is maintained by a fancy package, do not edit -->"
   news_lines <- c(
     fancy, "",

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -19,7 +19,6 @@ test_that("Can parse conventional commits", {
 })
 
 test_that("Will use commits", {
-
   local_demo_project(quiet = TRUE)
   commits_df <- tibble::tibble(
     message = c("one", "two"),
@@ -65,7 +64,7 @@ test_that("Can parse PR merge commits", {
     expect_snapshot_tibble(
       extract_newsworthy_items(
         "Merge pull request #332 from cynkra/conventional-parsing"
-        )
+      )
     )
   })
 })
@@ -92,7 +91,8 @@ test_that("Can parse PR merge commits - linked issues", {
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
     expect_snapshot_tibble(
-      extract_newsworthy_items("Merge pull request #328 from cynkra/blop"))
+      extract_newsworthy_items("Merge pull request #328 from cynkra/blop")
+    )
   })
 })
 

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -59,7 +59,7 @@ test_that("Can parse PR merge commits", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
 
   with_mock_dir("pr", {
-    withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
+    withr::local_envvar("FLEDGE_YES_INTERNET_TEST" = "yes")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
     expect_snapshot_tibble(
@@ -74,7 +74,7 @@ test_that("Can parse PR merge commits - external contributor", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
 
   with_mock_dir("pr0", {
-    withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
+    withr::local_envvar("FLEDGE_YES_INTERNET_TEST" = "yes")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
     expect_snapshot(suppressMessages(
@@ -88,7 +88,7 @@ test_that("Can parse PR merge commits - linked issues", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
 
   with_mock_dir("pr2", {
-    withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
+    withr::local_envvar("FLEDGE_YES_INTERNET_TEST" = "yes")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
     expect_snapshot_tibble(
@@ -101,7 +101,7 @@ test_that("Can parse PR merge commits - internet error", {
   withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
   withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
-  withr::local_envvar("NO_INTERNET_TEST_FLEDGE" = "blop")
+  withr::local_envvar("FLEDGE_NO_INTERNET_TEST" = "no")
 
   expect_snapshot(
     extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing")

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -113,9 +113,9 @@ test_that("Can parse PR merge commits - PAT absence", {
   withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
   withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
   withr::local_envvar("FLEDGE_TEST_NO_PAT" = "blop")
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, {
     extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing")
-  )
+  })
 })
 
 test_that("Can parse PR merge commits - other error", {

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -31,28 +31,48 @@ test_that("Will use commits", {
   )
 
   update_news(which = "minor")
-  file.copy("NEWS.md", "NEWS-merge.md")
-  expect_snapshot_file("NEWS-merge.md")
+
+  expect_snapshot_file("NEWS.md", "NEWS-merge.md")
 })
 
 test_that("Can parse Co-authored-by", {
-  expect_snapshot(extract_newsworthy_items("- blop\n-blip\n\nCo-authored-by: Person (<person@users.noreply.github.com>)"))
-  expect_snapshot(extract_newsworthy_items("- blop (#42)\n\nCo-authored-by: Person (<person@users.noreply.github.com>)\nCo-authored-by: Someone Else (<else@users.noreply.github.com>)"))
-  expect_snapshot(extract_newsworthy_items("feat: blop (#42)\n\nCo-authored-by: Person (<person@users.noreply.github.com>)"))
+  expect_snapshot(
+    extract_newsworthy_items(
+      "- blop\n-blip\n\nCo-authored-by: Person (<person@users.noreply.github.com>)"
+    )
+  )
+
+  expect_snapshot(
+    extract_newsworthy_items(
+      "- blop (#42)\n\nCo-authored-by: Person (<person@users.noreply.github.com>)\nCo-authored-by: Someone Else (<else@users.noreply.github.com>)"
+    )
+  )
+
+  expect_snapshot(
+    extract_newsworthy_items(
+      "feat: blop (#42)\n\nCo-authored-by: Person (<person@users.noreply.github.com>)"
+    )
+  )
 })
 
 test_that("Can parse PR merge commits", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
+
   with_mock_dir("pr", {
     withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
-    expect_snapshot_tibble(extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing"))
+    expect_snapshot_tibble(
+      extract_newsworthy_items(
+        "Merge pull request #332 from cynkra/conventional-parsing"
+        )
+    )
   })
 })
 
 test_that("Can parse PR merge commits - external contributor", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
+
   with_mock_dir("pr0", {
     withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
@@ -66,11 +86,13 @@ test_that("Can parse PR merge commits - external contributor", {
 
 test_that("Can parse PR merge commits - linked issues", {
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
+
   with_mock_dir("pr2", {
     withr::local_envvar("YES_INTERNET_TEST_FLEDGE" = "bla")
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
-    expect_snapshot_tibble(extract_newsworthy_items("Merge pull request #328 from cynkra/blop"))
+    expect_snapshot_tibble(
+      extract_newsworthy_items("Merge pull request #328 from cynkra/blop"))
   })
 })
 
@@ -80,7 +102,10 @@ test_that("Can parse PR merge commits - internet error", {
   withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
   withr::local_envvar("FLEDGE_TEST_GITHUB_SLUG" = "cynkra/fledge")
   withr::local_envvar("NO_INTERNET_TEST_FLEDGE" = "blop")
-  expect_snapshot(extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing"))
+
+  expect_snapshot(
+    extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing")
+  )
 })
 
 test_that("Can parse PR merge commits - PAT absence", {
@@ -88,7 +113,9 @@ test_that("Can parse PR merge commits - PAT absence", {
   withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
   withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
   withr::local_envvar("FLEDGE_TEST_NO_PAT" = "blop")
-  expect_snapshot_error(extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing"))
+  expect_snapshot_error(
+    extract_newsworthy_items("Merge pull request #332 from cynkra/conventional-parsing")
+  )
 })
 
 test_that("Can parse PR merge commits - other error", {
@@ -100,6 +127,8 @@ test_that("Can parse PR merge commits - other error", {
   with_mock_dir("pr", {
     withr::local_envvar("FLEDGE_TEST_SCOPES" = "bla")
     withr::local_envvar("GITHUB_PAT" = "ghp_111111111111111111111111111111111111111")
-    expect_snapshot_tibble(harvest_pr_data("Merge pull request #332 from cynkra/conventional-parsing"))
+    expect_snapshot_tibble(
+      harvest_pr_data("Merge pull request #332 from cynkra/conventional-parsing")
+    )
   })
 })

--- a/tests/testthat/test-parse-news-items.R
+++ b/tests/testthat/test-parse-news-items.R
@@ -1,5 +1,6 @@
 test_that("Can parse conventional commits", {
   withr::local_envvar("FLEDGE_DATE" = "2023-01-23")
+  withr::local_options(usethis.quiet = TRUE)
 
   repo <- withr::local_tempdir()
   withr::local_dir(repo)
@@ -13,7 +14,7 @@ test_that("Can parse conventional commits", {
     force = TRUE
   )
 
-  update_news(messages, which = "patch")
+  shut_up_fledge(update_news(messages, which = "patch"))
 
   expect_snapshot_file("NEWS.md")
 })
@@ -29,7 +30,7 @@ test_that("Will use commits", {
     default_commit_range = function() commits_df
   )
 
-  update_news(which = "minor")
+  shut_up_fledge(update_news(which = "minor"))
 
   expect_snapshot_file("NEWS.md", "NEWS-merge.md")
 })

--- a/tests/testthat/test-tag_version.R
+++ b/tests/testthat/test-tag_version.R
@@ -19,7 +19,7 @@ test_that("tag_version() works", {
   gert::git_add("R/pof.R")
   gert::git_commit("* Add cool pof.")
 
-  expect_snapshot_error(shut_up_fledge(tag_version(force = FALSE)))
+  expect_snapshot(error = TRUE, shut_up_fledge(tag_version(force = FALSE)))
 
   ## Same, but forcing ----
   expect_snapshot({

--- a/tests/testthat/test-tag_version.R
+++ b/tests/testthat/test-tag_version.R
@@ -4,23 +4,25 @@ test_that("tag_version() works", {
   use_r("bla")
   gert::git_add("R/bla.R")
   gert::git_commit("* Add cool bla.")
-  expect_snapshot(variant = snapshot_variant("testthat"), {
+
+  expect_snapshot({
     tag_version()
     get_last_tag()[, c("name", "ref")]
   })
 
-  # Attempting tagging again without any new commit
-  expect_silent(shut_up_fledge(tag_version()))
+  ## Attempting tagging again without any new commit ----
+  shut_up_fledge(tag_version())
 
-  # Attempting tagging again
+  ## Attempting tagging again ----
   # with a new commit but same version
   use_r("pof")
   gert::git_add("R/pof.R")
   gert::git_commit("* Add cool pof.")
+
   expect_snapshot_error(shut_up_fledge(tag_version(force = FALSE)))
 
-  # Same, but forcing
-  expect_snapshot(variant = snapshot_variant("testthat"), {
+  ## Same, but forcing ----
+  expect_snapshot({
     tag_version(force = TRUE)
     get_last_tag()[, c("name", "ref")]
   })

--- a/tests/testthat/test-tag_version.R
+++ b/tests/testthat/test-tag_version.R
@@ -1,5 +1,4 @@
 test_that("tag_version() works", {
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   local_demo_project(quiet = TRUE)
 
   use_r("bla")

--- a/tests/testthat/test-unbump_version.R
+++ b/tests/testthat/test-unbump_version.R
@@ -1,36 +1,23 @@
 test_that("unbump_version() works", {
-  skip_if_not_installed("rlang", "1.0.1")
 
-  tempdir <- withr::local_tempdir(pattern = "fledge-unbump")
   rlang::local_interactive(value = FALSE)
-  repo <- create_demo_project(
-    open = FALSE,
-    dir = tempdir,
-    news = TRUE,
-    maintainer = "Jane Doe",
-    email = "mail@example.com"
-  )
-  usethis::with_project(
-    path = repo,
-    {
-      withr::local_options(usethis.quiet = TRUE)
-      withr::local_envvar(FLEDGE_UNBUMP_TEST_COMMIT = "42")
-      use_r("bla")
-      gert::git_add("R/bla.R")
-      gert::git_commit("* Add cool bla.", author = default_gert_author(), committer = default_gert_committer())
-      testthat::expect_snapshot(variant = snapshot_variant("testthat"), {
-        bump_version()
-        unbump_version()
-        use_r("blop")
-        gert::git_add("R/blop.R")
-        c <- gert::git_commit("* Add cool blop.", author = default_gert_author(), committer = default_gert_committer())
-        bump_version()
-      })
-    },
-    quiet = TRUE
-  )
-  testthat::expect_snapshot_file(
-    file.path(repo, "NEWS.md"),
-    compare = compare_file_text
-  )
+  withr::local_options(usethis.quiet = TRUE)
+  withr::local_envvar(FLEDGE_UNBUMP_TEST_COMMIT = "42")
+
+  local_demo_project(quiet = TRUE)
+
+  use_r("bla")
+  gert::git_add("R/bla.R")
+  gert::git_commit("* Add cool bla.", author = default_gert_author(), committer = default_gert_committer())
+
+  testthat::expect_snapshot({
+    bump_version()
+    unbump_version()
+    use_r("blop")
+    gert::git_add("R/blop.R")
+    c <- gert::git_commit("* Add cool blop.", author = default_gert_author(), committer = default_gert_committer())
+    bump_version()
+  })
+
+  testthat::expect_snapshot_file("NEWS.md", compare = compare_file_text)
 })

--- a/tests/testthat/test-unbump_version.R
+++ b/tests/testthat/test-unbump_version.R
@@ -1,7 +1,6 @@
 test_that("unbump_version() works", {
   skip_if_not_installed("rlang", "1.0.1")
 
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
   tempdir <- withr::local_tempdir(pattern = "fledge-unbump")
   rlang::local_interactive(value = FALSE)
   repo <- create_demo_project(

--- a/tests/testthat/test-unbump_version.R
+++ b/tests/testthat/test-unbump_version.R
@@ -1,5 +1,4 @@
 test_that("unbump_version() works", {
-
   rlang::local_interactive(value = FALSE)
   withr::local_options(usethis.quiet = TRUE)
   withr::local_envvar(FLEDGE_UNBUMP_TEST_COMMIT = "42")

--- a/tests/testthat/test-update-news.R
+++ b/tests/testthat/test-update-news.R
@@ -62,7 +62,6 @@ test_that("regroup_news() works", {
 })
 
 test_that("Can update dev version news item", {
-  local_options(repos = NULL) # because of usethis::use_news_md() -> available.packages()
 
   withr::local_options("usethis.quiet" = TRUE)
   repo <- withr::local_tempdir(pattern = "devpkg")

--- a/tests/testthat/test-update-news.R
+++ b/tests/testthat/test-update-news.R
@@ -1,17 +1,16 @@
 test_that("update_news() works when news file absent", {
-  withr::local_options("fledge.quiet" = TRUE)
-  withr::local_options("usethis.quiet" = TRUE)
   local_demo_project(news = FALSE, quiet = TRUE)
-  expect_no_error(update_news(which = "patch"))
+  expect_no_error(
+    shut_up_fledge(update_news(which = "patch"))
+  )
 })
 
 test_that("update_news() works when news file still empty", {
-  withr::local_options("usethis.quiet" = TRUE)
   withr::local_envvar("FLEDGE_DATE" = "2023-01-23")
 
   local_demo_project(news = FALSE, quiet = TRUE)
   file.create("NEWS.md")
-  expect_no_error(update_news(which = "patch"))
+  expect_no_error(shut_up_fledge(update_news(which = "patch")))
 
   local_options(pillar.width = 240)
   expect_snapshot(read_fledgling())
@@ -19,6 +18,7 @@ test_that("update_news() works when news file still empty", {
 
 test_that("normalize_news() works", {
   withr::local_options("usethis.quiet" = TRUE)
+
   repo <- withr::local_tempdir()
   withr::local_dir(repo)
   usethis::with_project(
@@ -26,6 +26,7 @@ test_that("normalize_news() works", {
     usethis::use_description(fields = list(Package = "fledge")),
     force = TRUE
   )
+
   df <- tibble::tribble(
     ~description,
     "fledge has better support.",
@@ -39,17 +40,19 @@ test_that("normalize_news() works", {
 })
 
 test_that("regroup_news() works", {
-  withr::local_options("usethis.quiet" = TRUE)
+
   news_list1 <- list(
     Uncategorized = c("- blop", "- etc"),
     Documentation = c("- stuff", "- other")
   )
+
   news_list2 <- list(
     Features = c("- feat1", "- feat2"),
     `Custom type` = "cool right",
     Uncategorized = c("- pof", "- ok"),
     Documentation = "- again"
   )
+
   combined <- c(news_list1, news_list2)
   regrouped <- regroup_news(combined)
 
@@ -62,59 +65,43 @@ test_that("regroup_news() works", {
 })
 
 test_that("Can update dev version news item", {
-
+  skip_if_offline()
   withr::local_options("usethis.quiet" = TRUE)
+
   repo <- withr::local_tempdir(pattern = "devpkg")
 
-  create_cc_repo(
-    repo,
-    commit_messages = "feat: new stuff"
-  )
+  create_cc_repo(repo, commit_messages = "feat: new stuff")
+  usethis::local_project(repo, force = TRUE, setwd = TRUE)
 
-  usethis::with_project(
-    repo,
+  usethis::use_description(
+    fields = list(Package = "fledge", Version = "0.1.0")
+  )
+  withr::with_options(
+    list(repos = c("CRAN" = "https://cloud.r-project.org")),
     {
-      usethis::use_description(
-        fields = list(Package = "fledge", Version = "0.1.0")
-      )
-      withr::with_options(
-        list(repos = c("CRAN" = "https://cloud.r-project.org")),
-        {
-          usethis::use_news_md()
-        }
-      )
-      usethis::use_dev_version()
-    },
-    force = TRUE
-  )
-  expect_snapshot_file(
-    file.path(repo, "NEWS.md"),
-    name = "samedev-base.md"
+      usethis::use_news_md()
+    }
   )
 
-  usethis::local_project(repo, force = TRUE, setwd = FALSE)
-  withr::with_dir(repo, update_news())
-  expect_snapshot_file(
-    file.path(repo, "NEWS.md"),
-    name = "samedev.md"
-  )
+  usethis::use_dev_version()
 
-  # regrouping!
-  sort_of_commit("fix: horrible bug", repo = repo)
-  sort_of_commit("feat: neat helper", repo = repo)
-  withr::with_dir(repo, update_news())
-  expect_snapshot_file(
-    file.path(repo, "NEWS.md"),
-    name = "samedev-updated.md"
-  )
+  expect_snapshot_file("NEWS.md", "samedev-base.md")
+
+  shut_up_fledge(update_news())
+  expect_snapshot_file("NEWS.md", name = "samedev.md")
+
+  ## regrouping! ----
+  sort_of_commit("fix: horrible bug")
+  sort_of_commit("feat: neat helper")
+  shut_up_fledge(update_news())
+  expect_snapshot_file("NEWS.md", "samedev-updated.md")
 })
 
 test_that("Message when creating the news file", {
   withr::local_envvar("FLEDGE_DATE" = "2023-03-20")
-  local_demo_project(news = FALSE)
-  update_news()
-  expect_snapshot_file(
-    "NEWS.md",
-    name = "newchangelog.md"
-  )
+  local_demo_project(news = FALSE, quiet = TRUE)
+
+  shut_up_fledge(update_news())
+
+  expect_snapshot_file("NEWS.md", "newchangelog.md")
 })

--- a/tests/testthat/test-update-news.R
+++ b/tests/testthat/test-update-news.R
@@ -40,7 +40,6 @@ test_that("normalize_news() works", {
 })
 
 test_that("regroup_news() works", {
-
   news_list1 <- list(
     Uncategorized = c("- blop", "- etc"),
     Documentation = c("- stuff", "- other")

--- a/tests/testthat/test-with_demo_project.R
+++ b/tests/testthat/test-with_demo_project.R
@@ -1,6 +1,5 @@
 test_that("with_demo_project errors informatively", {
-  skip_if_not_installed("rlang", "1.0.1")
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, {
     with_demo_project(1 + 1, dir = "unexisting-dir")
-  )
+  })
 })


### PR DESCRIPTION
Fix #695
Part of #714

- Breaking up tests into paragraphs or even more tests;
- Removing the variants and the version skips that are outdated;
- Using testthat for mocking;
- Not using `expect_snapshot_error(`;
- Making all test switches' names start with `FLEDGE_`;
- Use the internal local helper everywhere.