### PR TITLE
fix: Update bump-version.R - replace length test in get_main_branch_config()

### DIFF
--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -95,17 +95,17 @@ get_main_branch_remote <- function(remote, repo) {
   basename(as.character(remotes$symref[remotes$ref == "HEAD"]))
 }
 
-get_main_branch_config <- function(repo) {
+  get_main_branch_config <- function(repo) {
+  #retrieve config of repo, filter down to init.defaultbranch values
   config <- gert::git_config(repo)
   init <- config[config$name == "init.defaultbranch", ]
-  local <- init[init$level == "local", ]
 
-  if (length(local)) {
-    return(local$value)
+  #return local default branch if it exists, otherwise default to global
+  if("local" %in% init$level){
+    return(init[init$level == "local",]$value)
+  } else { 
+    return(init[init$level == "global",]$value)
   }
-
-  global <- init[init$level == "global"]
-  return(global$value)
 }
 
 no_change <- function(ref = "HEAD") {

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -99,9 +99,9 @@ get_main_branch_config <- function(repo) {
   config <- gert::git_config(repo)
   init <- config[config$name == "init.defaultbranch", ]
 
-  if("local" %in% init$level){
+  if ("local" %in% init$level) {
     return(init[init$level == "local",]$value)
-  } else { 
+  } else {
     return(init[init$level == "global",]$value)
   }
 }

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -96,11 +96,9 @@ get_main_branch_remote <- function(remote, repo) {
 }
 
 get_main_branch_config <- function(repo) {
-  #retrieve config of repo, filter down to init.defaultbranch values
   config <- gert::git_config(repo)
   init <- config[config$name == "init.defaultbranch", ]
 
-  #return local default branch if it exists, otherwise default to global
   if("local" %in% init$level){
     return(init[init$level == "local",]$value)
   } else { 

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -95,7 +95,7 @@ get_main_branch_remote <- function(remote, repo) {
   basename(as.character(remotes$symref[remotes$ref == "HEAD"]))
 }
 
-  get_main_branch_config <- function(repo) {
+get_main_branch_config <- function(repo) {
   #retrieve config of repo, filter down to init.defaultbranch values
   config <- gert::git_config(repo)
   init <- config[config$name == "init.defaultbranch", ]

--- a/tests/testthat/_snaps/demo/demo.md
+++ b/tests/testthat/_snaps/demo/demo.md
@@ -33,7 +33,7 @@ A real project will live somewhere in your home directory.
 The `usethis::create_package()` function sets up a package project ready for development.
 
 
-```r
+``` r
 pkg <- usethis::create_package("tea")
 ```
 
@@ -48,14 +48,14 @@ For this demo, we manually set the active project.
 
 
 
-```r
+``` r
 usethis::proj_set()
 ```
 
 The infrastructure files and directories that comprise a minimal R package are created:
 
 
-```r
+``` r
 fs::dir_ls()
 ## DESCRIPTION NAMESPACE   R           tea.Rproj
 ```
@@ -68,10 +68,13 @@ We achieved this with gert code.
 You could use `usethis::use_git()` function that creates an initial commit, and the repository is in a clean state.
 
 
-```r
+``` r
 # Number of commits until now
 nrow(gert::git_log())
 ## [1] 1
+```
+
+``` r
 # Anything staged?
 gert::git_status()
 ## # A tibble: 0 x 3
@@ -81,7 +84,7 @@ gert::git_status()
 For working in branches, it is recommended to turn off fast-forward merging:
 
 
-```r
+``` r
 gert::git_config_set("merge.ff", "false")
 # gert::git_config_global_set("merge.ff", "false") # to set globally
 ```
@@ -98,7 +101,7 @@ We create two functions to show the contents and tags of the remote.
 In real life, you'd probably simply browse the GitHub interface for instance!
 
 
-```r
+``` r
 show_files <- function(remote_url) {
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
   withr::with_dir(tempdir_remote, {
@@ -109,6 +112,9 @@ show_files <- function(remote_url) {
 }
 show_files(remote_url)
 ## remote/DESCRIPTION remote/NAMESPACE   remote/tea.Rproj
+```
+
+``` r
 
 show_tags <- function(remote_url) {
   tempdir_remote <- withr::local_tempdir(pattern = "remote")
@@ -125,7 +131,7 @@ show_tags <- function(remote_url) {
 An initial NEWS file can be created with `usethis::use_news_md()`.
 
 
-```r
+``` r
 usethis::use_news_md()
 ## v Writing 'NEWS.md'
 ```
@@ -133,7 +139,7 @@ usethis::use_news_md()
 Let's take a look at the contents:
 
 
-```r
+``` r
 news <- readLines(usethis::proj_path("NEWS.md"))
 cat(news, sep = "\n")
 ## # tea (development version)
@@ -144,14 +150,14 @@ cat(news, sep = "\n")
 This file needs to be tracked by Git:
 
 
-```r
+``` r
 gert::git_add("NEWS.md")
 gert::git_commit("Initial NEWS.md .")
 gert::git_push(remote = "origin")
 ```
 
 
-```r
+``` r
 show_files(remote_url)
 ## remote/DESCRIPTION remote/NAMESPACE   remote/NEWS.md     remote/tea.Rproj
 ```
@@ -168,9 +174,12 @@ Now we start coding in the functionality for the package.
 We start by creating the new R file called `cup.R` and adding code (well only a comment).
 
 
-```r
+``` r
 usethis::use_r("cup")
 ## * Edit 'R/cup.R'
+```
+
+``` r
 writeLines("# cup", "R/cup.R")
 ```
 
@@ -186,14 +195,14 @@ It does not matter how and where you type the commit message (gert in R, RStudio
 What's important is the content of the commit message.
 
 
-```r
+``` r
 gert::git_add("R/cup.R")
 gert::git_commit("- New cup_of_tea() function makes it easy to drink a cup of tee.")
 gert::git_push()
 ```
 
 
-```r
+``` r
 show_files(remote_url)
 ## remote/DESCRIPTION remote/NAMESPACE   remote/NEWS.md     remote/R           
 ## remote/R/cup.R     remote/tea.Rproj
@@ -204,7 +213,7 @@ show_files(remote_url)
 The code in `cup.R` warrants a test (at least it would if it were actual code!):
 
 
-```r
+``` r
 usethis::use_test("cup")
 ## v Adding 'testthat' to Suggests field in DESCRIPTION
 ## v Adding '3' to Config/testthat/edition
@@ -212,6 +221,9 @@ usethis::use_test("cup")
 ## v Writing 'tests/testthat.R'
 ## v Writing 'tests/testthat/test-cup.R'
 ## * Edit 'tests/testthat/test-cup.R'
+```
+
+``` r
 cat(readLines("tests/testthat/test-cup.R"), sep = "\n")
 ## test_that("multiplication works", {
 ##   expect_equal(2 * 2, 4)
@@ -222,7 +234,7 @@ In a real project we would substitute the testing code from the template by real
 In this demo we commit straight away, **again with a bulleted message**.
 
 
-```r
+``` r
 gert::git_add("DESCRIPTION")
 gert::git_add("tests/testthat.R")
 gert::git_add("tests/testthat/test-cup.R")
@@ -231,7 +243,7 @@ gert::git_push()
 ```
 
 
-```r
+``` r
 show_files(remote_url)
 ## remote/DESCRIPTION               remote/NAMESPACE                 
 ## remote/NEWS.md                   remote/R                         
@@ -246,7 +258,7 @@ Let us look at the commit history until now.
 You might use any Git tool you want to consult it, we use gert.
 
 
-```r
+``` r
 # Only show number of files, messages
 knitr::kable(gert::git_log()[-(1:3)])
 ```
@@ -271,7 +283,7 @@ We use `fledge::bump_version()` to assign a new dev version number to the packag
 The current version number of our package is 0.0.0.9000.
 
 
-```r
+``` r
 fledge::bump_version()
 ## > Digesting messages from 4 commits.
 ## v Found 2 NEWS-worthy entries.
@@ -305,7 +317,7 @@ If you have pushed or edited code in the meantime, it's too late -- just continu
 Let us see what `NEWS.md` looks like after that bump.
 
 
-```r
+``` r
 news <- readLines("NEWS.md")
 cat(news, sep = "\n")
 ## <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
@@ -326,7 +338,7 @@ The fledge package adds a comment about not editing `NEWS.md` by hand to `NEWS.m
 Let's fix the typo, which you'd do by hand.
 
 
-```r
+``` r
 news <- gsub("tee", "tea", news)
 cat(news, sep = "\n")
 ## <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
@@ -336,6 +348,9 @@ cat(news, sep = "\n")
 ## - Add tests for cup of tea.
 ## - New cup_of_tea() function makes it easy to drink a cup of tea.
 ## - Added a `NEWS.md` file to track changes to the package.
+```
+
+``` r
 writeLines(news, "NEWS.md")
 ```
 
@@ -354,10 +369,13 @@ It should be called when `NEWS.md` is manually updated.
 Note that it should be called after `fledge::bump_version()`, an error is raised if another commit has been added after that.
 
 
-```r
+``` r
 show_tags(remote_url)
 ## # A tibble: 0 x 2
 ## # i 2 variables: name <chr>, ref <chr>
+```
+
+``` r
 fledge::finalize_version(push = TRUE)
 ## > Resetting to previous commit.
 ## > Committing changes.
@@ -368,6 +386,9 @@ fledge::finalize_version(push = TRUE)
 ## > Creating tag v0.0.0.9001 with tag message derived from 'NEWS.md'.
 ## > Force-pushing tag v0.0.0.9001.
 ## > Pushing main.
+```
+
+``` r
 show_tags(remote_url)
 ## # A tibble: 1 x 2
 ##   name        ref                  
@@ -378,7 +399,7 @@ show_tags(remote_url)
 Let's look at NEWS.md now:
 
 
-```r
+``` r
 news <- readLines("NEWS.md")
 cat(news, sep = "\n")
 ## <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
@@ -401,7 +422,7 @@ This requires changes to the code, and perhaps a new test.
 We create a branch (whose name starts with a "f" for "feature") and switch to this branch to implement this.
 
 
-```r
+``` r
 gert::git_branch_create("f-bowl", checkout = TRUE)
 ```
 
@@ -411,28 +432,31 @@ These commit messages do not need to be formatted specially, because {fledge} wi
 This time we write the tests first, test-driven development.
 
 
-```r
+``` r
 usethis::use_test("bowl")
 ## v Writing 'tests/testthat/test-bowl.R'
 ## * Edit 'tests/testthat/test-bowl.R'
 ```
 
 
-```r
+``` r
 gert::git_add("tests/testthat/test-bowl.R")
 gert::git_commit("Add bowl tests.")
 ```
 
 
 
-```r
+``` r
 usethis::use_r("bowl")
 ## * Edit 'R/bowl.R'
+```
+
+``` r
 writeLines("# bowl of tea", "R/bowl.R")
 ```
 
 
-```r
+``` r
 gert::git_add("R/bowl.R")
 gert::git_commit("Add bowl implementation.")
 ```
@@ -445,10 +469,13 @@ You might be used to doing the merges on a remote (e.g. GitHub pull requests) bu
 Earlier, we set the `merge.ff` config option to `"false"` to achieve this.
 
 
-```r
+``` r
 gert::git_branch_checkout("main")
 gert::git_merge("f-bowl", commit = FALSE)
 ## Merge was not committed due to merge conflict(s). Please fix and run git_commit() or git_merge_abort()
+```
+
+``` r
 gert::git_commit("- New bowl_of_tea() function makes it easy to drink a bowl of tea.")
 ```
 
@@ -457,7 +484,7 @@ The same strategy can be used when merging a pull/merge/... request on GitHub, G
 Now that we have added bowl support to our package, it is time to bump the version again.
 
 
-```r
+``` r
 fledge::bump_version()
 ## > Digesting messages from 2 commits.
 ## v Found 1 NEWS-worthy entry.
@@ -476,6 +503,9 @@ fledge::bump_version()
 ## 
 ## > Creating tag v0.0.0.9002 with tag message derived from 'NEWS.md'.
 ## ! Run `fledge::finalize_version(push = TRUE)`.
+```
+
+``` r
 news <- readLines("NEWS.md")
 writeLines(news)
 ## <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
@@ -490,6 +520,9 @@ writeLines(news)
 ## - Add tests for cup of tea.
 ## - New cup_of_tea() function makes it easy to drink a cup of tea.
 ## - Added a `NEWS.md` file to track changes to the package.
+```
+
+``` r
 fledge::finalize_version(push = TRUE)
 ## > Resetting to previous commit.
 ## > Committing changes.
@@ -517,7 +550,7 @@ We wish to release this package as a patch and so we use `fledge::bump_version()
 Other values for the arguments are "dev" (default), "minor" and "major".
 
 
-```r
+``` r
 fledge::bump_version("patch")
 ## > Digesting messages from 1 commits.
 ## i Same as previous version.
@@ -544,7 +577,7 @@ This updates the version of our package to 0.0.1.
 We review the `NEWS.md` that were generated by {fledge}:
 
 
-```r
+``` r
 news <- readLines("NEWS.md")
 cat(news, sep = "\n")
 ## <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
@@ -588,12 +621,15 @@ At this stage, {fledge} can help to tag the released version and create a new ve
 It is now the time to tag the released version using the `fledge::tag_version()` function.
 
 
-```r
+``` r
 fledge::tag_version()
 ## 
 ## -- Tagging Version --
 ## 
 ## > Creating tag v0.0.1 with tag message derived from 'NEWS.md'.
+```
+
+``` r
 show_tags(remote_url)
 ## # A tibble: 2 x 2
 ##   name        ref                  
@@ -615,7 +651,7 @@ We will now make the package ready for future development.
 The `fledge::bump_version()` takes care of it.
 
 
-```r
+``` r
 fledge::bump_version()
 ## > Digesting messages from 1 commits.
 ## i Same as previous version.
@@ -634,6 +670,9 @@ fledge::bump_version()
 ## 
 ## > Creating tag v0.0.1.9000 with tag message derived from 'NEWS.md'.
 ## ! Run `fledge::finalize_version(push = TRUE)`.
+```
+
+``` r
 news <- readLines("NEWS.md")
 ```
 
@@ -643,6 +682,6 @@ Happy development, and happy smooth filling of the changelog!
 
 
 
-```r
+``` r
 unlink(parent_dir, recursive = TRUE)
 ```


### PR DESCRIPTION
Closes #767 
length(table) always returns the number of columns, even for an empty (no rows) table. New test looks for the string "local" in init$level.