### PR TITLE
draft: Wipe news column

### DIFF
--- a/R/fledgling.R
+++ b/R/fledgling.R
@@ -124,6 +124,8 @@ read_news <- function(news_lines = NULL) {
   }
   section_df$news <- map(section_df$news, fix_name_and_level)
 
+  section_df$news <- NA_character_
+
   # create, update or re-use preamble
   is_preamble_absent <- (section_df[["start"]][[1]] == 1)
   if (is_preamble_absent) {

--- a/tests/testthat/_snaps/fledgling.md
+++ b/tests/testthat/_snaps/fledgling.md
@@ -7,9 +7,7 @@
           "end": 8,
           "h2": false,
           "raw": "# fledge v2.0.0\n\n* blop\n\n* lala\n",
-          "news": {
-            "Uncategorized": ["- blop", "", "- lala"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "fledge v2.0.0",
           "version": "2.0.0",
@@ -21,9 +19,7 @@
           "end": 14,
           "h2": false,
           "raw": "# fledge v1.0.0\n\n* blip\n\n* lili\n",
-          "news": {
-            "Uncategorized": ["- blip", "", "- lili"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "fledge v1.0.0",
           "version": "1.0.0",
@@ -44,9 +40,7 @@
           "end": 9,
           "h2": false,
           "raw": "# Changes in v2.0.0\n\n* blop\n\n* lala\n\n",
-          "news": {
-            "Uncategorized": ["- blop", "", "- lala"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v2.0.0",
           "version": "2.0.0",
@@ -58,9 +52,7 @@
           "end": 15,
           "h2": false,
           "raw": "# Changes in v1.0.0\n\n* blip\n\n* lili\n",
-          "news": {
-            "Uncategorized": ["- blip", "", "- lili"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v1.0.0",
           "version": "1.0.0",
@@ -81,9 +73,7 @@
           "end": 8,
           "h2": false,
           "raw": "# Changes in v2.0.0 \"Vigorous Calisthenics\"\n\n* blop\n\n* lala\n",
-          "news": {
-            "Uncategorized": ["- blop", "", "- lala"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v2.0.0 \"Vigorous Calisthenics\"",
           "version": "2.0.0",
@@ -95,9 +85,7 @@
           "end": 14,
           "h2": false,
           "raw": "# Changes in v1.0.0 \"Pumpkin Helmet\"\n\n* blip\n\n* lili\n",
-          "news": {
-            "Uncategorized": ["- blip", "", "- lili"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v1.0.0 \"Pumpkin Helmet\"",
           "version": "1.0.0",
@@ -118,9 +106,7 @@
           "end": 8,
           "h2": true,
           "raw": "## Changes in v2.0.0 \"Vigorous Calisthenics\"\n\n* blop\n\n* lala\n",
-          "news": {
-            "Uncategorized": ["- blop", "", "- lala"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v2.0.0 \"Vigorous Calisthenics\"",
           "version": "2.0.0",
@@ -132,9 +118,7 @@
           "end": 14,
           "h2": true,
           "raw": "## Changes in v1.0.0 \"Pumpkin Helmet\"\n\n* blip\n\n* lili\n",
-          "news": {
-            "Uncategorized": ["- blip", "", "- lili"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "Changes in v1.0.0 \"Pumpkin Helmet\"",
           "version": "1.0.0",
@@ -155,9 +139,7 @@
           "end": 7,
           "h2": false,
           "raw": "fledge v2.0.0\n=============\n\n* blop\n\n* lala\n",
-          "news": {
-            "Uncategorized": ["- blop", "", "- lala"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "fledge v2.0.0",
           "version": "2.0.0",
@@ -169,9 +151,7 @@
           "end": 13,
           "h2": false,
           "raw": "# fledge v1.0.0\n\n* blip\n\n* lili\n",
-          "news": {
-            "Uncategorized": ["- blip", "", "- lili"]
-          },
+          "news": "NA",
           "section_state": "keep",
           "title": "fledge v1.0.0",
           "version": "1.0.0",

--- a/tests/testthat/_snaps/update-news.md
+++ b/tests/testthat/_snaps/update-news.md
@@ -23,9 +23,9 @@
         raw                                                                           
         <chr>                                                                         
       1 "# tea 0.0.1 (2023-01-23)\n\n- Added a `NEWS.md` file to track changes to the~
-        news             section_state title                  version date    nickname
-        <list>           <chr>         <chr>                  <chr>   <chr>   <chr>   
-      1 <named list [1]> keep          tea 0.0.1 (2023-01-23) 0.0.1   (2023-~ <NA>    
+        news  section_state title                  version date         nickname
+        <chr> <chr>         <chr>                  <chr>   <chr>        <chr>   
+      1 <NA>  keep          tea 0.0.1 (2023-01-23) 0.0.1   (2023-01-23) <NA>    
       
       $preamble_in_file
       [1] TRUE


### PR DESCRIPTION
Computing it up front is way too costly.

Next steps:

- [ ] Fix tests by running `pandoc` or perhaps `md4r` as needed on the `raw` column, leave empty lines between entries
- [ ] Remove eager running of `pandoc`
- [ ] Enjoy faster operation and tests