### PR TITLE
documentation: update function reference links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ For informative commit messages refer to the [Tidyverse style guide](https://sty
 
 Then, for **full fledge use = fledge-assisted management of NEWS.md, DESCRIPTION version numbers, and git tags**:
 
-- Run [`fledge::bump_version()`](https://cynkra.github.io/fledge/reference/bump_version.html) regularly e.g. before every coffee break or at the end of the day or of the week. If you forgot to merge one PR run [`fledge::unbump_version()`](https://cynkra.github.io/fledge/reference/unbump_version.html), merge the PR with an informative squash commit message, then run [`fledge::bump_version()`](https://cynkra.github.io/fledge/reference/bump_version.html) and go drink that coffee!
+- Run [`fledge::bump_version()`](https://fledge.cynkra.com/reference/bump_version.html) regularly e.g. before every coffee break or at the end of the day or of the week. If you forgot to merge one PR run [`fledge::unbump_version()`](https://fledge.cynkra.com/reference/unbump_version.html), merge the PR with an informative squash commit message, then run [`fledge::bump_version()`](https://fledge.cynkra.com/reference/bump_version.html) and go drink that coffee!
 
-- Run [`fledge::finalize_version()`](https://cynkra.github.io/fledge/reference/finalize_version.html) if you need to edit `NEWS.md` manually e.g. if you made a typo or are not happy with a phrasing in retrospect. Even if you edit a lot, what’s been written in by fledge is still a good place-holder.
+- Run [`fledge::finalize_version()`](https://fledge.cynkra.com/reference/finalize_version.html) if you need to edit `NEWS.md` manually e.g. if you made a typo or are not happy with a phrasing in retrospect. Even if you edit a lot, what’s been written in by fledge is still a good place-holder.
 
 - Follow the recommended steps at release (see `vignette("fledge")` usage section).
 
@@ -71,7 +71,7 @@ OR, for **light fledge use = filling of NEWS.md between releases**:
 <pre class='chroma'>
 <span><span class='c'># mypackage (development version)</span></span></pre>
 
-- Regularly run [`fledge::update_news()`](https://cynkra.github.io/fledge/reference/update_news.html), preferentially on the main branch to avoid merge conflicts.
+- Regularly run [`fledge::update_news()`](https://fledge.cynkra.com/reference/update_news.html), preferentially on the main branch to avoid merge conflicts.
 
 These habits are worth learning!
 
@@ -112,8 +112,8 @@ If you are used to making workflow packages (e.g. [devtools](https://usethis.r-
 
 - If your package…
 
-  - is brand-new, remember to run [`fledge::bump_version()`](https://cynkra.github.io/fledge/reference/bump_version.html) regularly.
-  - has already undergone some development, it is not too late to jump on the train! Run [`fledge::bump_version()`](https://cynkra.github.io/fledge/reference/bump_version.html) and then [`fledge::finalize_version()`](https://cynkra.github.io/fledge/reference/finalize_version.html).
+  - is brand-new, remember to run [`fledge::bump_version()`](https://fledge.cynkra.com/reference/bump_version.html) regularly.
+  - has already undergone some development, it is not too late to jump on the train! Run [`fledge::bump_version()`](https://fledge.cynkra.com/reference/bump_version.html) and then [`fledge::finalize_version()`](https://fledge.cynkra.com/reference/finalize_version.html).
 
 ##### For light use
 


### PR DESCRIPTION
this should happen automatically in the future, once the next {fledge} update comes to CRAN