### PR TITLE
ci: Conditionally install fledge package based on repository

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -99,8 +99,9 @@ jobs:
       - uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          pak-version: devel
+          packages: ${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}
           cache-version: fledge-1
-          packages: local::.
 
       - name: Count rulesets
         # Assume that branch is protected if ruleset exists

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -99,7 +99,6 @@ jobs:
       - uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pak-version: devel
           packages: ${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}
           cache-version: fledge-1
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Passed on to r-lib/actions/setup-r-dependencies@v2
     required: false
     default: 1
+  pak-version:
+    description: Passed on to r-lib/actions/setup-r-dependencies@v2
+    required: false
+    default: stable
 
 runs:
   using: "composite"
@@ -114,7 +118,7 @@ runs:
       env:
         GITHUB_PAT: ${{ inputs.token }}
       with:
-        pak-version: stable
+        pak-version: ${{ inputs.pak-version }}
         needs: ${{ inputs.needs }}
         packages: ${{ inputs.packages }}
         extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: Passed on to r-lib/actions/setup-r-dependencies@v2
     required: false
     default: 1
-  pak-version:
-    description: Passed on to r-lib/actions/setup-r-dependencies@v2
-    required: false
-    default: stable
 
 runs:
   using: "composite"
@@ -118,7 +114,7 @@ runs:
       env:
         GITHUB_PAT: ${{ inputs.token }}
       with:
-        pak-version: ${{ inputs.pak-version }}
+        pak-version: stable
         needs: ${{ inputs.needs }}
         packages: ${{ inputs.packages }}
         extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to conditionally install the fledge package based on whether the workflow is running in the main repository or a fork.

## Key Changes
- Modified the `packages` input in the workflow to use a conditional expression
- When running in the `cynkra/fledge` repository, installs the local package (`local::.`)
- When running in forks, installs from the remote repository (`cynkra/fledge`)
- Reordered workflow inputs for better readability (moved `packages` before `cache-version`)

## Implementation Details
The change uses a GitHub Actions expression `${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}` to dynamically determine which package source to use, enabling the workflow to work correctly in both the main repository and forked repositories.

https://claude.ai/code/session_01TzBzFTo8aBzNdfXbE4PzKj